### PR TITLE
Add turbo and importmaps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,10 @@ PATH
   remote: .
   specs:
     mission_control-jobs (0.1.0)
+      importmap-rails
       rails (>= 7.0.3.1)
+      stimulus-rails
+      turbo-rails
 
 GEM
   remote: https://rubygems.org/
@@ -104,6 +107,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    importmap-rails (1.1.5)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
     json (2.6.2)
     loofah (2.18.0)
       crass (~> 1.0.2)
@@ -233,10 +239,16 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
+    stimulus-rails (1.1.0)
+      railties (>= 6.0.0)
     strscan (3.0.4)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.0)
+    turbo-rails (1.1.1)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)

--- a/app/assets/config/mission_control_jobs_manifest.js
+++ b/app/assets/config/mission_control_jobs_manifest.js
@@ -1,1 +1,3 @@
 //= link_directory ../stylesheets/mission_control/jobs .css
+//= link_directory ../../javascript/mission_control/jobs .js
+//= link_directory ../../javascript/mission_control/jobs/controllers .js

--- a/app/javascript/mission_control/jobs/application.js
+++ b/app/javascript/mission_control/jobs/application.js
@@ -1,0 +1,3 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "@hotwired/turbo-rails"
+import "controllers"

--- a/app/javascript/mission_control/jobs/controllers/application.js
+++ b/app/javascript/mission_control/jobs/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/mission_control/jobs/controllers/index.js
+++ b/app/javascript/mission_control/jobs/controllers/index.js
@@ -1,0 +1,11 @@
+// Import and register all your controllers from the importmap under controllers/*
+
+import { application } from "controllers/application"
+
+// Eager load all controllers defined in the import map under controllers/**/*_controller
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)
+
+// Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
+// import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
+// lazyLoadControllersFrom("controllers", application)

--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -6,7 +6,8 @@
   <%= csp_meta_tag %>
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
-  <%= stylesheet_link_tag    "mission_control/jobs/application", media: "all" %>
+  <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
+  <%= javascript_importmap_tags %>
 </head>
 <body>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,5 @@
+pin "application", to: "mission_control/jobs/application.js", preload: true
+pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
+pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
+pin_all_from MissionControl::Jobs::Engine.root.join("app/javascript/mission_control/jobs/controllers"), under: "controllers", to: "mission_control/jobs/controllers"

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -1,6 +1,10 @@
 require "mission_control/jobs/version"
 require "mission_control/jobs/engine"
 
+require "importmap-rails"
+require "turbo-rails"
+require "stimulus-rails"
+
 module MissionControl
   module Jobs
     class Engine < ::Rails::Engine
@@ -25,6 +29,16 @@ module MissionControl
             delete_adapters_data
           end
         end
+      end
+
+      initializer "mission_control-jobs.assets" do |app|
+        app.config.assets.paths << root.join("app/javascript")
+        app.config.assets.precompile += %w[ mission_control_jobs_manifest ]
+      end
+
+      initializer "mission_control-jobs.importmap", before: "importmap" do |app|
+        app.config.importmap.paths << root.join("config/importmap.rb")
+        app.config.importmap.cache_sweepers << root.join("app/javascript")
       end
     end
   end

--- a/mission_control-jobs.gemspec
+++ b/mission_control-jobs.gemspec
@@ -21,6 +21,9 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.0.3.1"
+  spec.add_dependency 'importmap-rails'
+  spec.add_dependency 'turbo-rails'
+  spec.add_dependency 'stimulus-rails'
 
   spec.add_development_dependency "resque"
   spec.add_development_dependency "capybara"


### PR DESCRIPTION
Adds `turbo` with `stimulus` and `importmaps` to the engine.

I wanted to have a modern JS setup for building the admin screens. It took me some back and forth to get everything working.

@basecamp/sip @lewispb @dhh 
