### PR TITLE
Customize parent controller class

### DIFF
--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -1,4 +1,4 @@
-class MissionControl::Jobs::ApplicationController < ActionController::Base
+class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_controller_class.constantize
   layout "mission_control/jobs/application"
 
   private

--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -11,5 +11,6 @@ require "mission_control/jobs/engine"
 module MissionControl
   module Jobs
     mattr_accessor :applications, default: MissionControl::Jobs::Applications.new
+    mattr_accessor :base_controller_class, default: "::ApplicationController"
   end
 end

--- a/test/mission_control/jobs/base_application_controller_test.rb
+++ b/test/mission_control/jobs/base_application_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MissionControl::Jobs::BaseApplicationControllerTest < ActiveSupport::TestCase
+  test "engine's ApplicationController inherits from host's ApplicationController by default" do
+    assert MissionControl::Jobs::ApplicationController < ApplicationController
+  end
+end


### PR DESCRIPTION
Customize parent controller class for the engine controllers.

It defaults to `::ApplicationController`, which is the `ApplicationController` in the host app. This is intended to get the engine use the authentication controls from Dash when we install it.

Similar to what [we do in audits1984](https://github.com/basecamp/audits1984#authenticate-auditors) but simpler, no need to return a specific user object with information here. This makes the assumption that just by inheriting from `ApplicationController` you get authentication, which is enough for Dash. We could add fine-grained options in the future if we need too, going simple for now.

https://3.basecamp.com/2914079/buckets/28546948/todos/5200976280

@basecamp/sip @lewispb