### PR TITLE
Load queues information in a single transaction using multi

### DIFF
--- a/lib/active_job/querying.rb
+++ b/lib/active_job/querying.rb
@@ -21,8 +21,8 @@ module ActiveJob::Querying
 
     private
       def fetch_queues
-        queue_adapter.queue_names.collect do |queue_name|
-          ActiveJob::Queue.new(queue_name, queue_adapter: queue_adapter)
+        queue_adapter.queues.collect do |queue|
+          ActiveJob::Queue.new(queue[:name], size: queue[:size], active: queue[:active], queue_adapter: queue_adapter)
         end
       end
   end

--- a/test/active_job/queue_adapters/adapter_testing/queues.rb
+++ b/test/active_job/queue_adapters/adapter_testing/queues.rb
@@ -29,11 +29,11 @@ module ActiveJob::QueueAdapters::AdapterTesting::Queues
     assert_not queue.paused?
 
     queue.pause
-    assert_not queue.active?
+    assert_not queue.reload.active?
     assert queue.paused?
 
     queue.resume
-    assert queue.active?
+    assert queue.reload.active?
     assert_not queue.paused?
   end
 


### PR DESCRIPTION
This will be much faster for fetching and rendering the initial list of queues.

Currently, it's very slow to render the list of queues when there are redis latencies between Dash and the targeted datacenter. For each queue, we were performing a redis request to determine the number of jobs and the status of the queue. For 60 queues and high latencies, this was resulting in 2-4s to load the queues for BC3 Ashburn and HEY.

@basecamp/sip 