### PR TITLE
Safer API around activating Active job adapters

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/application_scoped.rb
+++ b/app/controllers/concerns/mission_control/jobs/application_scoped.rb
@@ -3,7 +3,7 @@ module MissionControl::Jobs::ApplicationScoped
 
   included do
     before_action :set_application
-    around_action :activate_job_server
+    around_action :activating_job_server
 
     delegate :applications, to: MissionControl::Jobs
   end
@@ -22,13 +22,11 @@ module MissionControl::Jobs::ApplicationScoped
       end
     end
 
-    def activate_job_server
+    def activating_job_server(&block)
       @original_redis = Resque.redis
       @server = find_server or raise MissionControl::Jobs::Errors::ResourceNotFound, "Server not found"
       MissionControl::Jobs::Current.server = @server
-      yield
-    ensure
-      Resque.redis = @original_redis
+      @server.activating(&block)
     end
 
     def find_server

--- a/app/models/mission_control/jobs/current.rb
+++ b/app/models/mission_control/jobs/current.rb
@@ -1,8 +1,3 @@
 class MissionControl::Jobs::Current < ActiveSupport::CurrentAttributes
   attribute :application, :server
-
-  def server=(server)
-    super
-    server.activate
-  end
 end

--- a/lib/active_job/executing.rb
+++ b/lib/active_job/executing.rb
@@ -6,7 +6,7 @@ module ActiveJob::Executing
   included do
     attr_accessor :last_execution_error
     attr_reader :serialized_arguments
-    thread_cattr_accessor :_current_queue_adapter
+    thread_cattr_accessor :current_queue_adapter
   end
 
   def failed?
@@ -16,15 +16,6 @@ module ActiveJob::Executing
   class_methods do
     def queue_adapter
       current_queue_adapter || super
-    end
-
-    def current_queue_adapter=(adapter)
-      self._current_queue_adapter = adapter
-      adapter.try(:activate)
-    end
-
-    def current_queue_adapter
-      _current_queue_adapter
     end
   end
 

--- a/lib/active_job/queue_adapters/resque_ext.rb
+++ b/lib/active_job/queue_adapters/resque_ext.rb
@@ -4,8 +4,12 @@ module ActiveJob::QueueAdapters::ResqueExt
     @redis = redis
   end
 
-  def activate
+  def activating(&block)
+    original_redis = Resque.redis
     Resque.redis = @redis
+    block.call
+  ensure
+    Resque.redis = original_redis
   end
 
   def queue_names

--- a/lib/mission_control/jobs/server.rb
+++ b/lib/mission_control/jobs/server.rb
@@ -8,14 +8,10 @@ class MissionControl::Jobs::Server
     @queue_adapter = queue_adapter
   end
 
-  def activate
-    ActiveJob::Base.current_queue_adapter = queue_adapter
-  end
-
   def activating(&block)
     previous_adapter = ActiveJob::Base.current_queue_adapter
-    activate
-    block.call
+    ActiveJob::Base.current_queue_adapter = queue_adapter
+    queue_adapter.activating(&block)
   ensure
     ActiveJob::Base.current_queue_adapter = previous_adapter
   end

--- a/test/active_job/queue_adapters/queue_adapter_test.rb
+++ b/test/active_job/queue_adapters/queue_adapter_test.rb
@@ -3,27 +3,6 @@ require "test_helper"
 class ActiveJob::QueueAdapters::QueueAdapterTest < ActiveSupport::TestCase
   include ResqueHelper
 
-  test "assigning a resque adapter will activate it" do
-    old_redis = create_resque_redis "old"
-    Resque.redis = old_redis
-
-    new_redis = create_resque_redis "new"
-    adapter = ActiveJob::QueueAdapters::ResqueAdapter.new(new_redis)
-
-    assert_changes -> { current_resque_redis }, from: old_redis, to: new_redis do
-      ActiveJob::Base.current_queue_adapter = adapter
-    end
-  end
-
-  test "changing the current resque adapter" do
-    current_adapter = ActiveJob::Base.queue_adapter
-    new_adapter = ActiveJob::QueueAdapters::ResqueAdapter.new
-
-    assert_changes -> { ActiveJob::Base.queue_adapter }, from: current_adapter, to: new_adapter do
-      ActiveJob::Base.current_queue_adapter = new_adapter
-    end
-  end
-
   test "changing current resque adapter is thread-safe" do
     2.times.collect { ActiveJob::QueueAdapters::ResqueAdapter.new }.flat_map do |new_adapter|
       20.times.collect do

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,10 +7,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   include MissionControl::Jobs::Engine.routes.url_helpers
 
-  setup do
+  def run
     # Activate default job server so that setup data before any navigation
     # happens is loaded there.
-    default_job_server.activate
+    default_job_server.activating do
+      super
+    end
   end
 
   # UI tests just use Resque for now

--- a/test/mission_control/jobs/server_test.rb
+++ b/test/mission_control/jobs/server_test.rb
@@ -1,12 +1,19 @@
 require "test_helper"
 
 class MissionControl::Jobs::ServerTest < ActiveSupport::TestCase
-  test "activate changes Active Job's current queue adapter" do
-    queue_adapter = ActiveJob::QueueAdapters::ResqueAdapter.new
-    server = MissionControl::Jobs::Server.new(name: "foo", queue_adapter: queue_adapter)
+  test "activating a queue adapter" do
+    current_adapter = ActiveJob::Base.queue_adapter
+    new_adapter = ActiveJob::QueueAdapters::ResqueAdapter.new
+    server = MissionControl::Jobs::Server.new(name: "bc3", queue_adapter: new_adapter)
 
-    assert_changes -> { ActiveJob::Base.current_queue_adapter }, to: queue_adapter do
-      server.activate
+    assert_equal current_adapter, ActiveJob::Base.queue_adapter
+
+    server.activating do
+      @executed = true
+      assert_equal new_adapter, ActiveJob::Base.queue_adapter
     end
+
+    assert @executed
+    assert_equal current_adapter, ActiveJob::Base.queue_adapter
   end
 end


### PR DESCRIPTION
We had a [little incident](https://3.basecamp.com/2914079/buckets/245/chats/111192@5303166961) where the engine could left the wrong redis instance configured. This made some Dash's jobs to get enqueued in BC3 and HEY.  I prepared an [initial patch](https://github.com/basecamp/mission_control-jobs/commit/0e442d4b3c98477adae035659028762c4ccf68a4) and moved the wrong jobs back to Dash. 

This change is intended to make this impossible from happening again by design. Now, all the queue adapter activations will happen within a block invocation, that will make sure to restore the previous adapter back.

@basecamp/sip 
