### PR TITLE
Fix missing retry button on Jobs table

### DIFF
--- a/app/assets/stylesheets/mission_control/jobs/jobs.css
+++ b/app/assets/stylesheets/mission_control/jobs/jobs.css
@@ -1,3 +1,7 @@
 .filter input {
     width: 15rem;
 }
+
+.jobs td {
+    word-break: break-all;
+}


### PR DESCRIPTION
When a long unbroken string is displayed (e.g. a comma separated list of queue names), it can cause the rightmost column containing the retry and discard buttons to be off the right edge of the page, and inaccesible.

This change allows those lines to break.

**Before**

<img width="1254" alt="Screenshot 2022-11-07 at 15 13 07" src="https://user-images.githubusercontent.com/1773614/200346301-86c1178f-c0f0-44a1-a0b7-49a87437af32.png">

**After**

<img width="1352" alt="Screenshot 2022-11-07 at 15 13 12" src="https://user-images.githubusercontent.com/1773614/200346319-dd136ee9-7c02-4604-82b8-086484c40dde.png">
