### PR TITLE
Filter by prefix only in the queues list page, not everywhere

### DIFF
--- a/app/controllers/mission_control/jobs/queues_controller.rb
+++ b/app/controllers/mission_control/jobs/queues_controller.rb
@@ -2,7 +2,7 @@ class MissionControl::Jobs::QueuesController < MissionControl::Jobs::Application
   before_action :set_queue
 
   def index
-    @queues = ApplicationJob.queues.sort_by(&:name)
+    @queues = filtered_queues.sort_by(&:name)
   end
 
   def show
@@ -12,5 +12,13 @@ class MissionControl::Jobs::QueuesController < MissionControl::Jobs::Application
   private
     def set_queue
       @queue = ApplicationJob.queues[params[:id]]
+    end
+
+    def filtered_queues
+      if prefix = ApplicationJob.queue_name_prefix
+        ApplicationJob.queues.select { |queue| queue.name.start_with?(prefix) }
+      else
+        ApplicationJob.queues
+      end
     end
 end

--- a/lib/active_job/querying.rb
+++ b/lib/active_job/querying.rb
@@ -22,9 +22,7 @@ module ActiveJob::Querying
     private
       def fetch_queues
         queue_adapter.queues.collect do |queue|
-          if !queue_name_prefix || queue[:name].start_with?(queue_name_prefix)
-            ActiveJob::Queue.new(queue[:name], size: queue[:size], active: queue[:active], queue_adapter: queue_adapter)
-          end
+          ActiveJob::Queue.new(queue[:name], size: queue[:size], active: queue[:active], queue_adapter: queue_adapter)
         end.compact
       end
   end


### PR DESCRIPTION
Otherwise, we'd end up returning 404 when accessing some jobs directly, which is undesirable.

This is a follow up to #24 