### PR TITLE
Configure what adapters should be loaded into Mission Control

### DIFF
--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -10,6 +10,7 @@ loader.setup
 
 module MissionControl
   module Jobs
+    mattr_accessor :adapters, default: Set.new
     mattr_accessor :applications, default: MissionControl::Jobs::Applications.new
     mattr_accessor :base_controller_class, default: "::ApplicationController"
     mattr_accessor :delay_between_bulk_operation_batches, default: 0

--- a/lib/mission_control/jobs/identified_elements.rb
+++ b/lib/mission_control/jobs/identified_elements.rb
@@ -3,7 +3,7 @@
 class MissionControl::Jobs::IdentifiedElements
   include Enumerable
 
-  delegate :[], to: :elements
+  delegate :[], :empty?, to: :elements
   delegate :each, :last, :length, to: :to_a
 
   def initialize

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -3,11 +3,13 @@ require_relative "boot"
 require "rails/all"
 require "resque"
 
+require "solid_queue"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 require "mission_control/jobs"
-require "solid_queue"
+
 
 module Dummy
   class Application < Rails::Application
@@ -23,5 +25,8 @@ module Dummy
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Mission Control supported adapters
+    config.mission_control.jobs.adapters = [ :resque, :solid_queue ]
   end
 end


### PR DESCRIPTION
If none is configured and there's an active job queue adapter configured, use that by default.

In this way, the engine can load with apps that don't use resque or solid queue. Also, if no applications have been configured, just set them by default based on the adapters configured.