### PR TITLE
Order scheduled jobs by scheduled date first and warn about delayed ones

### DIFF
--- a/app/views/mission_control/jobs/jobs/scheduled/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/scheduled/_job.html.erb
@@ -1,2 +1,7 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
-<td><%= bidirectional_time_distance_in_words_with_title(job.scheduled_at) %></td>
+<td>
+  <%= bidirectional_time_distance_in_words_with_title(job.scheduled_at) %>
+  <% if job.scheduled_at.before? 1.minute.ago %>
+    <div class="is-danger tag ml-4">delayed</div>
+  <% end %>
+</td>

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -24,4 +24,17 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     get mission_control_jobs.application_job_url(@application, @job.job_id + "0", filter: { queue_name: "queue_1" })
     assert_redirected_to mission_control_jobs.application_queue_path(@application, :queue_1)
   end
+
+  test "get scheduled jobs" do
+    DummyJob.set(wait: 3.minutes).perform_later
+    DummyJob.set(wait: 1.minute).perform_later
+
+    travel_to 2.minutes.from_now
+
+    get mission_control_jobs.application_jobs_url(@application, :scheduled)
+
+    assert_select "tr.job", 2
+    assert_select "tr.job", /DummyJob\s+Enqueued 2 minutes ago\s+queue_1\s+in 1 minute/
+    assert_select "tr.job", /DummyJob\s+Enqueued 2 minutes ago\s+queue_1\s+less than a minute ago/
+  end
 end


### PR DESCRIPTION
With a "delayed" tag. Also, ensure `job.scheduled_at` is always set.