### PR TITLE
Return last Solid Queue job when there are several with the same Active Job ID

### DIFF
--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -83,7 +83,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
   end
 
   def find_job(job_id, *)
-    if job = SolidQueue::Job.find_by(active_job_id: job_id)
+    if job = SolidQueue::Job.where(active_job_id: job_id).order(:id).last
       deserialize_and_proxy_solid_queue_job job
     end
   end


### PR DESCRIPTION
This applies in the case of automatic retries performed by Active Job's retrying mechanism. In that case, the failing job finishes just fine, the exception is retried and Active Job re-enqueues the job, so for Solid Queue, these look like different jobs with the same Active Job ID. Normally, we'd be interested in the last one only, though, so just return that. In the future perhaps we can find a way to return all the instances if there are more.