### PR TITLE
use docker compose command based on version in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,8 +2,14 @@
 set -eu
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker-compose up -d --remove-orphans
-docker-compose ps
+if docker compose version &> /dev/null; then
+  DOCKER_COMPOSE_CMD="docker compose"
+else
+  DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+$DOCKER_COMPOSE_CMD up -d --remove-orphans
+$DOCKER_COMPOSE_CMD ps
 
 bundle
 


### PR DESCRIPTION
the command to execute docker compose in v2 is docker compose as opposed to docker-compose in v1

updated setup script to check the version of docker compose installed and invoke the appropriate command for compatibility with both versions

