### PR TITLE
Fully opt-out of turbo caching

### DIFF
--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -6,6 +6,7 @@
   <%= csp_meta_tag %>
 
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="turbo-cache-control" content="no-cache">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
   <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags "application-mcj" %>


### PR DESCRIPTION
Given the nature of mission control, you always want to have up to date information.

The current behaviour includes turbo caching, wich can make numbers and lists jump around a little when switching tabs.
This seems counter productive to me, so I suggest we  completely opt out of turbo caching for mission control