### PR TITLE
Use correct time zone for dates

### DIFF
--- a/app/helpers/mission_control/jobs/dates_helper.rb
+++ b/app/helpers/mission_control/jobs/dates_helper.rb
@@ -1,10 +1,10 @@
 module MissionControl::Jobs::DatesHelper
   def time_ago_in_words_with_title(time)
-    tag.span time_ago_in_words(time), title: time.to_fs(:long)
+    tag.span time_ago_in_words(time), title: time.in_time_zone.to_fs(:long)
   end
 
   def time_distance_in_words_with_title(time)
-    tag.span distance_of_time_in_words_to_now(time, include_seconds: true), title: "Since #{time.to_fs(:long)}"
+    tag.span distance_of_time_in_words_to_now(time, include_seconds: true), title: "Since #{time.in_time_zone.to_fs(:long)}"
   end
 
   def bidirectional_time_distance_in_words_with_title(time)
@@ -14,6 +14,6 @@ module MissionControl::Jobs::DatesHelper
       "in #{distance_of_time_in_words_to_now(time, include_seconds: true)}"
     end
 
-    tag.span time_distance, title: time.to_fs(:long)
+    tag.span time_distance, title: time.in_time_zone.to_fs(:long)
   end
 end


### PR DESCRIPTION
`ActiveJob::Core` sets the `enqueued_at` property in UTC : https://github.com/rails/rails/blob/a2d2155e0ecdf18c469ccdfd28ca225fd7a42795/activejob/lib/active_job/core.rb#L119

Some other properties such as `finished_at` are set in the current time zone.

To make sure we compare times within the same time zone, this PR ensures all datetimes displayed are `in_time_zone`