### PR TITLE
Make sure we do not register `Resque` as module when autoloading

### DIFF
--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -6,6 +6,7 @@ require "zeitwerk"
 loader = Zeitwerk::Loader.new
 loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
 loader.push_dir(File.expand_path("..", __dir__))
+loader.ignore("#{File.expand_path("..", __dir__)}/resque")
 loader.setup
 
 module MissionControl

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -36,6 +36,7 @@ module MissionControl
 
       config.before_initialize do
         if MissionControl::Jobs.adapters.include?(:resque)
+          require "resque/thread_safe_redis"
           ActiveJob::QueueAdapters::ResqueAdapter.prepend ActiveJob::QueueAdapters::ResqueExt
           Resque.prepend Resque::ThreadSafeRedis
         end

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -25,7 +25,7 @@ class JobsLoader
       load_finished_jobs
       load_failed_jobs
       load_regular_jobs
-      load_blocked_jobs if server.queue_adapter.supported_statuses.include?(:blocked)
+      load_blocked_jobs if server.queue_adapter.supported_job_statuses.include?(:blocked)
     end
   end
 


### PR DESCRIPTION
Although we might not directly load the `Resque::ThreadSafeRedis`, having the folder `lib/resque` in the Zeitwerk loader, will reserve the `Resque` name as module (`"/usr/local/bundle/gems/mission_control-jobs-0.2.0/lib/resque"=>[Object, :Resque]`)

This results in issues when other gems (like `rails_sementic_logger`) perform checks with `defined?(Resque)`.

This PR excludes the `lib/rescue` from Zeitwerk and requires the file only when required.

fixes #95 