### PR TITLE
Remove usage of deprecated thread_safe option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ require "resque_pause_helper"
 
 require "solid_queue"
 
-Resque.redis = Redis::Namespace.new "#{Rails.env}", redis: Redis.new(host: "localhost", port: 6379, thread_safe: true)
+Resque.redis = Redis::Namespace.new "#{Rails.env}", redis: Redis.new(host: "localhost", port: 6379)
 
 SERVERS_BY_APP = {
   BC4: %w[ resque_ashburn resque_chicago ],

--- a/test/dummy/config/initializers/mission_control_jobs.rb
+++ b/test/dummy/config/initializers/mission_control_jobs.rb
@@ -3,7 +3,7 @@ require "resque_pause_helper"
 
 require "solid_queue"
 
-Resque.redis = Redis::Namespace.new "#{Rails.env}", redis: Redis.new(host: "localhost", port: 6379, thread_safe: true)
+Resque.redis = Redis::Namespace.new "#{Rails.env}", redis: Redis.new(host: "localhost", port: 6379)
 
 SERVERS_BY_APP = {
   BC4: %w[ resque_ashburn resque_chicago ],

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,7 +63,7 @@ class ActiveSupport::TestCase
     end
 
     def root_resque_redis
-      @root_resque_redis ||= Redis.new(host: "localhost", port: 6379, thread_safe: true)
+      @root_resque_redis ||= Redis.new(host: "localhost", port: 6379)
     end
 
     def reset_configured_queues_for_job_classes


### PR DESCRIPTION
The `thread_safe` option was introduced in the redis-rb's 2.2.à release. Its usage was removed in 2012 (https://github.com/redis/redis-rb/commit/619fe28104ebb08f88802bae4e9b99769c93f722).

In newer versions of redis-rb ([>= 5.0.0](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#500)), deprecated options now result in an error raised:

> Redis.new will now raise an error if provided unknown options.

This is a proposal to remove `thread_safe: true` in the documentation and tests as it is not used, incompatible with newer version of the redis-rb gem and in any case `true` is the default value.