### PR TITLE
Passing a Hash to lset command results in a client error with redisb >= 5.0.0

### DIFF
--- a/lib/active_job/queue_adapters/resque_ext.rb
+++ b/lib/active_job/queue_adapters/resque_ext.rb
@@ -261,7 +261,7 @@ module ActiveJob::QueueAdapters::ResqueExt
           resque_job = job.raw_data
           resque_job["retried_at"] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
 
-          redis.lset(queue_redis_key, job.position, resque_job)
+          redis.lset(queue_redis_key, job.position, resque_job.to_json)
           Resque::Job.create(resque_job["queue"], resque_job["payload"]["class"], *resque_job["payload"]["args"])
         rescue Redis::CommandError => error
           handle_resque_job_error(job, error)


### PR DESCRIPTION
https://github.com/redis-rb/redis-client/commit/fa5c90329e766f8ea6e4904048924826c2cc59c8#diff-93ad1901b7d42d11445b6aa1cb2b71a7e99a26a40d2d3b4213511ccafc33d1cd ???

Bug on redis-client or mission-control?