### PR TITLE
Tidy up dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,7 @@
 # Want to disable a check for a specific case? To disable checks inline:
 # http://docs.rubocop.org/en/latest/configuration/#disabling-cops-within-source-code
 
-# Begin with the 37signals house style
-inherit_gem: { rubocop-37signals: rubocop.yml }
+inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
 AllCops:
   TargetRubyVersion: 3.0

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,4 @@ git_source(:bc)     { |repo| "https://github.com/basecamp/#{repo}" }
 # Specify your gem's dependencies in mission_control-jobs.gemspec.
 gemspec
 
-gem "sqlite3"
-
-gem "sprockets-rails"
-gem "solid_queue", bc: "solid_queue", branch: "cron-jobs-take-2", require: false
-gem "rubocop-37signals", bc: "house-style", require: false
-gem "puma"
 gem "capybara", github: "teamcapybara/capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,4 @@
 GIT
-  remote: https://github.com/basecamp/house-style
-  revision: a9ca7e4ab80b72c1a10053c50efefe8cd275e3b8
-  specs:
-    rubocop-37signals (1.0.0)
-      rubocop
-      rubocop-minitest
-      rubocop-performance
-      rubocop-rails
-
-GIT
-  remote: https://github.com/basecamp/solid_queue
-  revision: f2f10f593126669fd903092cf8d7901db7d521fa
-  branch: cron-jobs-take-2
-  specs:
-    solid_queue (0.2.1)
-      concurrent-ruby (~> 1.2.2)
-      fugit (~> 1.9.0)
-      rails (~> 7.1)
-
-GIT
   remote: https://github.com/teamcapybara/capybara.git
   revision: c0cbf4024c1abd48b0c22c2930e7b05af58ab284
   specs:
@@ -122,7 +102,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     builder (3.2.4)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -131,24 +111,23 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     erubi (1.12.0)
-    et-orbi (1.2.7)
+    et-orbi (1.2.11)
       tzinfo
     fugit (1.9.0)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.7.2)
-    irb (1.11.2)
+    irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
     json (2.7.1)
@@ -160,10 +139,10 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.2)
+    marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    minitest (5.22.2)
+    minitest (5.22.3)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
     mono_logger (1.1.2)
@@ -178,20 +157,20 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
-    nio4r (2.7.0)
-    nokogiri (1.16.2-aarch64-linux)
+    nio4r (2.7.1)
+    nokogiri (1.16.3-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.2-arm-linux)
+    nokogiri (1.16.3-arm-linux)
       racc (~> 1.4)
-    nokogiri (1.16.2-arm64-darwin)
+    nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86-linux)
+    nokogiri (1.16.3-x86-linux)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-darwin)
+    nokogiri (1.16.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -204,7 +183,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.7.3)
-    rack (3.0.9.1)
+    rack (3.0.10)
     rack-protection (4.0.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0, < 4)
@@ -245,14 +224,14 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.1.0)
-    rdoc (6.6.2)
+    rake (13.2.0)
+    rdoc (6.6.3.1)
       psych (>= 4.0.0)
     redis (4.0.3)
     redis-namespace (1.11.0)
       redis (>= 4)
     regexp_parser (2.9.0)
-    reline (0.4.3)
+    reline (0.5.0)
       io-console (~> 0.5)
     resque (2.6.0)
       mono_logger (~> 1.0)
@@ -286,6 +265,11 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
+    rubocop-rails-omakase (1.0.0)
+      rubocop
+      rubocop-minitest
+      rubocop-performance
+      rubocop-rails
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -300,6 +284,12 @@ GEM
       rack-protection (= 4.0.0)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
+    solid_queue (0.3.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (~> 1.2.2)
+      fugit (~> 1.9.0)
+      railties (>= 7.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -354,13 +344,12 @@ DEPENDENCIES
   resque
   resque-pause
   rubocop (~> 1.52.0)
-  rubocop-37signals!
   rubocop-performance
-  rubocop-rails
+  rubocop-rails-omakase
   selenium-webdriver
-  solid_queue!
+  solid_queue
   sprockets-rails
   sqlite3
 
 BUNDLED WITH
-   2.5.6
+   2.5.7

--- a/mission_control-jobs.gemspec
+++ b/mission_control-jobs.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", "~> 7.1"
-  spec.add_dependency 'importmap-rails'
-  spec.add_dependency 'turbo-rails'
-  spec.add_dependency 'stimulus-rails'
+  spec.add_dependency "importmap-rails"
+  spec.add_dependency "turbo-rails"
+  spec.add_dependency "stimulus-rails"
 
   spec.add_development_dependency "resque"
   spec.add_development_dependency "solid_queue"
@@ -31,5 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redis-namespace"
   spec.add_development_dependency "rubocop", "~> 1.52.0"
   spec.add_development_dependency "rubocop-performance"
-  spec.add_development_dependency "rubocop-rails"
+  spec.add_development_dependency "rubocop-rails-omakase"
+  spec.add_development_dependency "sprockets-rails"
+  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "puma"
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,8 +1,9 @@
 require_relative "boot"
 
 require "rails/all"
-require "resque"
+require "sprockets/railtie"
 
+require "resque"
 require "solid_queue"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
- Switch to RubyGems' Solid Queue version - this was an oversight of mine, it was still pointing to the Basecamp org in GitHub, and to a custom branch 😅 
- Use Rails' Rubocop omakase version
- Move gems that can be moved over to `.gemspec`