### PR TITLE
Resque adapter: Support queue pausing only if resque-pause is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Besides `base_controller_class`, you can also set the following for `MissionCont
 This library extends Active Job with a querying interface and the following setting:
 - `config.active_job.default_page_size`: the internal batch size that Active Job will use when sending queries to the underlying adapter and the batch size for the bulk operations defined above—defaults to `1000`.
 
+
+## Adapter Specifics
+
+- **Resque**: Queue pausing is supported only if you have `resque-pause` installed in your project
+
 ## Advanced configuration
 
 When we built Mission Control Jobs, we did it with the idea of managing multiple apps' job backends from a single, centralized app that we used for monitoring, alerts and other tools that related to all our apps. Some of our apps run in more than one datacenter, and we run different Resque instances with different Redis configurations in each. Because of this, we added support for multiple apps and multiple adapters per app. Even when running Mission Control Job within the app it manages, and a single DC, as we migrated from Resque to Solid Queue, we needed to manage both adapters from Mission Control.

--- a/lib/active_job/queue_adapters/resque_ext.rb
+++ b/lib/active_job/queue_adapters/resque_ext.rb
@@ -81,6 +81,10 @@ module ActiveJob::QueueAdapters::ResqueExt
     resque_jobs_for(jobs_relation).find_job(job_id)
   end
 
+  def supports_queue_pausing?
+    defined?(ResquePauseHelper)
+  end
+
   private
     attr_reader :redis
 

--- a/test/active_job/queue_adapters/resque_test.rb
+++ b/test/active_job/queue_adapters/resque_test.rb
@@ -3,7 +3,24 @@ require "test_helper"
 class ActiveJob::QueueAdapters::ResqueTest < ActiveSupport::TestCase
   include ActiveJob::QueueAdapters::AdapterTesting
 
+  test "it supports queue pausing when ResquePauseHelper is defined" do
+    assert ActiveJob::Base.queue_adapter.supports_queue_pausing?
+  end
+
+  test "it does not support queue pausing when ResquePauseHelper is not defined" do
+    emulating_resque_pause_gem_absence do
+      assert_not ActiveJob::Base.queue_adapter.supports_queue_pausing?
+    end
+  end
+
   private
+    def emulating_resque_pause_gem_absence
+      helper_const = Object.send(:remove_const, :ResquePauseHelper)
+      yield
+    ensure
+      Object.const_set(:ResquePauseHelper, helper_const)
+    end
+
     def queue_adapter
       :resque
     end

--- a/test/active_job/queue_adapters/resque_test.rb
+++ b/test/active_job/queue_adapters/resque_test.rb
@@ -3,11 +3,11 @@ require "test_helper"
 class ActiveJob::QueueAdapters::ResqueTest < ActiveSupport::TestCase
   include ActiveJob::QueueAdapters::AdapterTesting
 
-  test "it supports queue pausing when ResquePauseHelper is defined" do
+  test "supports queue pausing when ResquePauseHelper is defined" do
     assert ActiveJob::Base.queue_adapter.supports_queue_pausing?
   end
 
-  test "it does not support queue pausing when ResquePauseHelper is not defined" do
+  test "does not support queue pausing when ResquePauseHelper is not defined" do
     emulating_resque_pause_gem_absence do
       assert_not ActiveJob::Base.queue_adapter.supports_queue_pausing?
     end


### PR DESCRIPTION
Fixes #106

Pausing queues when using Resque only works if you have `resque-pause` installed. We need to check if `ResquePauseHelper` is available (as @jstrouse mentions in the issue), since it's used in methods such as `pause_queue` & `resume_queue` inside `ActiveJob::QueueAdapters::ResqueExt`

Tests should cover it, but you can also remove the `resque-pause` dependency from `mission_control-jobs.gemspec` and comment line 2 inside `test/dummy/config/initializers/mission_control_jobs.rb`. You should no longer see the "Pause" button when inspecting a queue (green button in the top right corner):

| With resque-pause | Without resque-pause |
| -------- | ------- |
| ![image](https://github.com/rails/mission_control-jobs/assets/57004457/a8fd5040-05fd-4a28-bc5c-3f07a92f5406) | <img src="https://github.com/rails/mission_control-jobs/assets/57004457/4dc1ce76-42da-490f-b57d-881b1210c7db"> |


