### PR TITLE
Order SolidQueue failed executuions by id desc

### DIFF
--- a/lib/active_job/queue_adapters/resque_ext.rb
+++ b/lib/active_job/queue_adapters/resque_ext.rb
@@ -115,14 +115,14 @@ module ActiveJob::QueueAdapters::ResqueExt
       end
 
       def all
-        @all ||= fetch_resque_jobs.collect.with_index { |resque_job, index| deserialize_resque_job(resque_job, index) if resque_job.is_a?(Hash) }.compact
+        @all ||= fetch_resque_jobs.collect { |resque_job, position| deserialize_resque_job(resque_job, position) if resque_job.is_a?(Hash) }.compact
       end
 
       def retry_all
         if use_batches?
           retry_all_in_batches
         else
-          retry_jobs(jobs_relation.to_a.reverse)
+          retry_jobs(jobs_relation.to_a)
         end
       end
 
@@ -165,6 +165,7 @@ module ActiveJob::QueueAdapters::ResqueExt
           !paginated? && !jobs_relation.filtering_needed?
         end
 
+        # Returns pairs of raw Resque job and its position in the Redis list
         def fetch_resque_jobs
           if jobs_relation.failed? || jobs_relation.queue_name.blank?
             fetch_failed_resque_jobs
@@ -173,24 +174,32 @@ module ActiveJob::QueueAdapters::ResqueExt
           end
         end
 
+        # Failed jobs are listed newest first, but Resque stores them oldest first,
+        # so read them from the end of the list, keeping their positions in it.
         def fetch_failed_resque_jobs
-          Array.wrap(Resque::Failure.all(jobs_relation.offset_value, jobs_relation.limit_value))
+          newest = failed_jobs_count - jobs_relation.offset_value - 1
+          oldest = [ newest - jobs_relation.limit_value + 1, 0 ].max
+          return [] if newest < 0
+
+          Array.wrap(Resque::Failure.all(oldest, newest - oldest + 1)).reverse.zip(newest.downto(oldest).to_a)
         end
 
         def fetch_queue_resque_jobs
           unless jobs_relation.queue_name.present?
             raise ActiveJob::Errors::QueryError, "This adapter requires a queue name unless fetching failed jobs"
           end
-          Array.wrap(Resque.peek(jobs_relation.queue_name, jobs_relation.offset_value, jobs_relation.limit_value))
+          Array.wrap(Resque.peek(jobs_relation.queue_name, jobs_relation.offset_value, jobs_relation.limit_value)).each_with_index.collect do |resque_job, index|
+            [ resque_job, jobs_relation.offset_value + index ]
+          end
         end
 
-        def deserialize_resque_job(resque_job_hash, index)
+        def deserialize_resque_job(resque_job_hash, position)
           args_hash = extract_args_hash(resque_job_hash)
           ActiveJob::JobProxy.new(args_hash).tap do |job|
             job.last_execution_error = execution_error_from_resque_job(resque_job_hash)
             job.raw_data = resque_job_hash
             job.filtered_raw_data = filter_raw_data_arguments(resque_job_hash)
-            job.position = jobs_relation.offset_value + index
+            job.position = position
             job.failed_at = resque_job_hash["failed_at"]&.to_datetime&.utc
             job.status = job.failed_at.present? ? :failed : :pending
           end
@@ -248,9 +257,14 @@ module ActiveJob::QueueAdapters::ResqueExt
         end
 
         def retry_jobs(jobs)
-          in_transactional_jobs_batches(jobs) do |jobs_batch|
+          in_transactional_jobs_batches(jobs_by_descending_position(jobs)) do |jobs_batch|
             jobs_batch.each { |job| retry_job(job) }
           end
+        end
+
+        # Removing a job shifts the ones after it in the list, so operate from the end
+        def jobs_by_descending_position(jobs)
+          jobs.sort_by(&:position).reverse
         end
 
         def in_transactional_jobs_batches(jobs)
@@ -288,12 +302,12 @@ module ActiveJob::QueueAdapters::ResqueExt
           if use_batches?
             discard_all_in_batches
           else
-            discard_jobs(jobs_relation.to_a.reverse)
+            discard_jobs(jobs_relation.to_a)
           end
         end
 
         def discard_jobs(jobs)
-          in_transactional_jobs_batches(jobs) do |jobs_batch|
+          in_transactional_jobs_batches(jobs_by_descending_position(jobs)) do |jobs_batch|
             jobs_batch.each { |job| discard(job) }
           end
         end

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -217,6 +217,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
           case
             # Follow polling order for scheduled executions, the rest by job_id, desc or asc
           when solid_queue_status.scheduled? then executions.ordered
+          when solid_queue_status.failed? then executions.order(id: :desc)
           when recurring_task_id.present?    then executions.order(job_id: :desc)
           else executions.order(job_id: :asc)
           end

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -215,7 +215,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
 
         def order_executions(executions)
           case
-            # Follow polling order for scheduled executions, the rest by job_id, desc or asc
+            # Follow polling order for scheduled executions, newest first for failed ones, the rest by job_id, desc or asc
           when solid_queue_status.scheduled? then executions.ordered
           when solid_queue_status.failed? then executions.order(id: :desc)
           when recurring_task_id.present?    then executions.order(job_id: :desc)

--- a/test/active_job/queue_adapters/adapter_testing/count_jobs.rb
+++ b/test/active_job/queue_adapters/adapter_testing/count_jobs.rb
@@ -98,8 +98,8 @@ module ActiveJob::QueueAdapters::AdapterTesting::CountJobs
   test "count failing jobs with offset, limit and job_class" do
     assert_equal 0, ActiveJob.jobs.failed.count
 
-    10.times { FailingJob.perform_later }
     10.times { FailingReloadedJob.perform_later }
+    10.times { FailingJob.perform_later }
     perform_enqueued_jobs
 
     assert_equal 7, ActiveJob.jobs.failed.where(job_class_name: "FailingJob").offset(3).count

--- a/test/active_job/queue_adapters/adapter_testing/discard_jobs.rb
+++ b/test/active_job/queue_adapters/adapter_testing/discard_jobs.rb
@@ -37,7 +37,7 @@ module ActiveJob::QueueAdapters::AdapterTesting::DiscardJobs
 
     assert_equal 7, ActiveJob.jobs.failed.count
 
-    [ 0, 1, 5, 6, 7, 8, 9 ].each.with_index do |expected_argument, index|
+    [ 9, 8, 4, 3, 2, 1, 0 ].each.with_index do |expected_argument, index|
       assert_equal [ expected_argument ], ActiveJob.jobs.failed[index].serialized_arguments
     end
   end

--- a/test/active_job/queue_adapters/adapter_testing/job_batches.rb
+++ b/test/active_job/queue_adapters/adapter_testing/job_batches.rb
@@ -3,13 +3,13 @@ module ActiveJob::QueueAdapters::AdapterTesting::JobBatches
   extend ActiveSupport::Testing::Declarative
 
   included do
-    # Ascending order
-    assert_loop jobs_count: 10, order: :asc, batch_size: 5, expected_batches: [ 0..4, 5..9 ]
-    assert_loop jobs_count: 12, order: :asc, batch_size: 5, expected_batches: [ 0..4, 5..9, 10..11 ]
+    # Failed jobs are listed newest first, so ascending batches start with the newest jobs
+    assert_loop jobs_count: 10, order: :asc, batch_size: 5, expected_batches: [ [ 9, 8, 7, 6, 5 ], [ 4, 3, 2, 1, 0 ] ]
+    assert_loop jobs_count: 12, order: :asc, batch_size: 5, expected_batches: [ [ 11, 10, 9, 8, 7 ], [ 6, 5, 4, 3, 2 ], [ 1, 0 ] ]
 
-    # Descending order
-    assert_loop jobs_count: 10, order: :desc, batch_size: 5, expected_batches: [ 5..9, 0..4 ]
-    assert_loop jobs_count: 12, order: :desc, batch_size: 5, expected_batches: [ 7..11, 2..6, 0..1 ]
+    # Descending batches start from the end, with the oldest jobs
+    assert_loop jobs_count: 10, order: :desc, batch_size: 5, expected_batches: [ [ 4, 3, 2, 1, 0 ], [ 9, 8, 7, 6, 5 ] ]
+    assert_loop jobs_count: 12, order: :desc, batch_size: 5, expected_batches: [ [ 4, 3, 2, 1, 0 ], [ 9, 8, 7, 6, 5 ], [ 11, 10 ] ]
   end
 
   class_methods do
@@ -24,8 +24,8 @@ module ActiveJob::QueueAdapters::AdapterTesting::JobBatches
         assert_equal expected_batches.length, batches.length
         batches.each { |batch| assert_instance_of ActiveJob::JobsRelation, batch }
 
-        expected_batches.each.with_index do |batch_range, index|
-          assert_equal batch_range.to_a, batches[index].to_a.collect(&:serialized_arguments).flatten
+        expected_batches.each.with_index do |batch_arguments, index|
+          assert_equal batch_arguments, batches[index].to_a.collect(&:serialized_arguments).flatten
         end
       end
 
@@ -39,8 +39,8 @@ module ActiveJob::QueueAdapters::AdapterTesting::JobBatches
         assert_equal expected_batches.length, batches.length
         batches.each { |batch| assert_instance_of ActiveJob::JobsRelation, batch }
 
-        expected_batches.each.with_index do |batch_range, index|
-          assert_equal batch_range.to_a, batches[index].to_a.collect(&:serialized_arguments).flatten
+        expected_batches.each.with_index do |batch_arguments, index|
+          assert_equal batch_arguments, batches[index].to_a.collect(&:serialized_arguments).flatten
         end
       end
     end

--- a/test/active_job/queue_adapters/adapter_testing/query_jobs.rb
+++ b/test/active_job/queue_adapters/adapter_testing/query_jobs.rb
@@ -44,8 +44,8 @@ module ActiveJob::QueueAdapters::AdapterTesting::QueryJobs
 
     jobs = ActiveJob.jobs.failed.limit(2).to_a
     assert_equal 2, jobs.size
-    assert_equal [ 0 ], jobs[0].serialized_arguments
-    assert_equal [ 1 ], jobs[1].serialized_arguments
+    assert_equal [ 9 ], jobs[0].serialized_arguments
+    assert_equal [ 8 ], jobs[1].serialized_arguments
   end
 
   test "enumerate jobs with offset without limit" do
@@ -54,8 +54,8 @@ module ActiveJob::QueueAdapters::AdapterTesting::QueryJobs
 
     jobs = ActiveJob.jobs.failed.offset(2).to_a
     assert_equal 8, jobs.size
-    assert_equal [ 2 ], jobs[0].serialized_arguments
-    assert_equal [ 9 ], jobs[7].serialized_arguments
+    assert_equal [ 7 ], jobs[0].serialized_arguments
+    assert_equal [ 0 ], jobs[7].serialized_arguments
   end
 
   test "enumerate jobs with offset and limit" do
@@ -64,8 +64,8 @@ module ActiveJob::QueueAdapters::AdapterTesting::QueryJobs
 
     jobs = ActiveJob.jobs.failed.offset(2).limit(2).to_a
     assert_equal 2, jobs.size
-    assert_equal [ 2 ], jobs[0].serialized_arguments
-    assert_equal [ 3 ], jobs[1].serialized_arguments
+    assert_equal [ 7 ], jobs[0].serialized_arguments
+    assert_equal [ 6 ], jobs[1].serialized_arguments
   end
 
   test "enumerate jobs when limit is greater than the available set" do
@@ -93,7 +93,7 @@ module ActiveJob::QueueAdapters::AdapterTesting::QueryJobs
 
     jobs.each.with_index do |job, index|
       assert_job_proxy WithPaginationFailingJob, job
-      assert [ index ], job.serialized_arguments[0]
+      assert_equal [ 9 - index ], job.serialized_arguments
     end
   end
 
@@ -104,8 +104,8 @@ module ActiveJob::QueueAdapters::AdapterTesting::QueryJobs
     jobs = WithPaginationFailingJob.jobs.failed.offset(2).limit(3).to_a
     assert_equal 3, jobs.size
 
-    assert_equal [ 2 ], jobs[0].serialized_arguments
-    assert_equal [ 4 ], jobs[2].serialized_arguments
+    assert_equal [ 7 ], jobs[0].serialized_arguments
+    assert_equal [ 5 ], jobs[2].serialized_arguments
   end
 
   test "fetch pending jobs when pagination kicks in and the first pages are empty due to filtering" do

--- a/test/active_job/queue_adapters/adapter_testing/retry_jobs.rb
+++ b/test/active_job/queue_adapters/adapter_testing/retry_jobs.rb
@@ -45,7 +45,7 @@ module ActiveJob::QueueAdapters::AdapterTesting::RetryJobs
 
     assert_equal 7, ActiveJob.jobs.failed.count
 
-    [ 0, 1, 5, 6, 7, 8, 9 ].each.with_index do |expected_argument, index|
+    [ 9, 8, 4, 3, 2, 1, 0 ].each.with_index do |expected_argument, index|
       assert_equal [ expected_argument ], ActiveJob.jobs.failed[index].serialized_arguments
     end
   end

--- a/test/system/discard_jobs_test.rb
+++ b/test/system/discard_jobs_test.rb
@@ -23,7 +23,7 @@ class DiscardJobsTest < ApplicationSystemTestCase
 
   test "discard a single job" do
     assert_equal 9, job_row_elements.length
-    expected_job_id = ActiveJob.jobs.failed[2].job_id
+    expected_job_id = ActiveJob.jobs.failed.find { |job| job.serialized_arguments == [ "failing-arg-2" ] }.job_id
 
     within_job_row "failing-arg-2" do
       accept_confirm do

--- a/test/system/list_failed_jobs_test.rb
+++ b/test/system/list_failed_jobs_test.rb
@@ -13,7 +13,7 @@ class ListFailedJobsTest < ApplicationSystemTestCase
     job_row_elements.each.with_index do |job_element, index|
       within job_element do
         assert_text "FailingJob"
-        assert_text "#{index}"
+        assert_text "#{9 - index}"
       end
     end
   end

--- a/test/system/paginate_jobs_test.rb
+++ b/test/system/paginate_jobs_test.rb
@@ -9,18 +9,18 @@ class PaginateJobsTest < ApplicationSystemTestCase
   end
 
   test "paginate failed jobs" do
-    assert_jobs 0..9
+    assert_jobs 19.downto(10)
 
     click_on "Next page"
-    assert_jobs 10..19
+    assert_jobs 9.downto(0)
 
     click_on "Previous page"
-    assert_jobs 0..9
+    assert_jobs 19.downto(10)
   end
 
   private
-    def assert_jobs(range)
-      expected_indexes = range.to_a
+    def assert_jobs(indexes)
+      expected_indexes = indexes.to_a
 
       # Wait for page to load
       assert_text /FailingJob\s*#{expected_indexes.first}/i

--- a/test/system/retry_jobs_test.rb
+++ b/test/system/retry_jobs_test.rb
@@ -22,7 +22,7 @@ class RetryJobsTest < ApplicationSystemTestCase
 
   test "retry a single job" do
     assert_equal 9, job_row_elements.length
-    expected_job_id = ActiveJob.jobs.failed[2].job_id
+    expected_job_id = ActiveJob.jobs.failed.find { |job| job.serialized_arguments == [ "failing-arg-2" ] }.job_id
 
     within_job_row "failing-arg-2" do
       click_on "Retry"


### PR DESCRIPTION
When inspecting the failed jobs, I want to see in an instant the most recent ones.

This seems to be the default in Sidekiq and GoodJob AFAICS.

 I was very surprised to see that this was not the case with mission control + solid queue, it actually made me miss some important dead jobs that were hidden in page 2.

This PR changes the ordering of failed executions so they are ordered by (failed execution) ~creation~ ID  DESC.