### PR TITLE
Update Bulma CSS to v1 w/ dark mode 🌙

### DIFF
--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -7,7 +7,7 @@
 
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="turbo-cache-control" content="no-cache">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.1/css/bulma.min.css">
   <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags "application-mcj" %>
 </head>


### PR DESCRIPTION
Dark mode support is nice to have:
<img width="1280" alt="Screenshot 2024-06-10 at 10 20 52 PM" src="https://github.com/rails/mission_control-jobs/assets/4392286/1f41688d-fd19-4ee2-9cd2-299d71fb25da">
