### PR TITLE
UiHelper => InterfaceHelper

### DIFF
--- a/app/helpers/mission_control/jobs/application_helper.rb
+++ b/app/helpers/mission_control/jobs/application_helper.rb
@@ -3,6 +3,6 @@ module MissionControl::Jobs
     # Explicit helper inclusion because ApplicationController inherits from the host app.
     #
     # We can't rely on +config.action_controller.include_all_helpers = true+ in the host app.
-    include DatesHelper, JobsHelper, NavigationHelper, UiHelper
+    include DatesHelper, JobsHelper, NavigationHelper, InterfaceHelper
   end
 end

--- a/app/helpers/mission_control/jobs/interface_helper.rb
+++ b/app/helpers/mission_control/jobs/interface_helper.rb
@@ -1,4 +1,4 @@
-module MissionControl::Jobs::UiHelper
+module MissionControl::Jobs::InterfaceHelper
   def blank_status_notice(message)
     tag.div message, class: "mt-6 has-text-centered is-size-3 has-text-grey"
   end


### PR DESCRIPTION
Fixes #129

In engines, it's best to avoid common acronyms to not disturb the host.