### PR TITLE
Stop filtering queues by prefix in the queues view

### DIFF
--- a/app/controllers/mission_control/jobs/queues_controller.rb
+++ b/app/controllers/mission_control/jobs/queues_controller.rb
@@ -2,7 +2,7 @@ class MissionControl::Jobs::QueuesController < MissionControl::Jobs::Application
   before_action :set_queue, only: :show
 
   def index
-    @queues = filtered_queues.sort_by(&:name)
+    @queues = ActiveJob.queues.sort_by(&:name)
   end
 
   def show
@@ -12,13 +12,5 @@ class MissionControl::Jobs::QueuesController < MissionControl::Jobs::Application
   private
     def set_queue
       @queue = ActiveJob.queues[params[:id]]
-    end
-
-    def filtered_queues
-      if prefix = ActiveJob::Base.queue_name_prefix
-        ActiveJob.queues.select { |queue| queue.name.start_with?(prefix) }
-      else
-        ActiveJob.queues
-      end
     end
 end

--- a/test/system/list_queues_test.rb
+++ b/test/system/list_queues_test.rb
@@ -15,23 +15,4 @@ class ListQueuesTest < ApplicationSystemTestCase
       end
     end
   end
-
-  test "list queues sorted by name and filtered by prefix" do
-    with_queue_name_prefix do
-      visit queues_path
-
-      assert_equal 1, queue_row_elements.length
-      within queue_row_elements.first do
-        assert_text "queue_1"
-      end
-    end
-  end
-
-  private
-    def with_queue_name_prefix(&block)
-      previous_prefix, ActiveJob::Base.queue_name_prefix = ActiveJob::Base.queue_name_prefix, "queue_1"
-      yield
-    ensure
-      ActiveJob::Base.queue_name_prefix = previous_prefix
-    end
 end


### PR DESCRIPTION
We don't do this anywhere else, so it was quite inconsistent 😅 