### PR TITLE
Enforce the locale to be set to `English`

### DIFF
--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -4,8 +4,14 @@ class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_co
   include MissionControl::Jobs::ApplicationScoped, MissionControl::Jobs::NotFoundRedirections
   include MissionControl::Jobs::AdapterFeatures
 
+  around_action :set_current_locale
+
   private
     def default_url_options
       { server_id: MissionControl::Jobs::Current.server }
+    end
+
+    def set_current_locale(&block)
+      I18n.with_locale(:en, &block)
     end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,4 @@
-version: "3.4"
-
 volumes:
-  db: {}
   redis: {}
 
 services:

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -82,4 +82,17 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
       assert_select "div.tag", text: /delayed/, count: 1 # total of one delayed tag
     end
   end
+
+  test "get jobs and job details the default locale is set to another language than English" do
+    I18n.available_locales = %i[en nl]
+
+    DummyJob.set(wait: 3.minutes).perform_later
+
+    I18n.with_locale(:nl) do
+      get mission_control_jobs.application_jobs_url(@application, :scheduled)
+      assert_response :ok
+
+      assert_select "tr.job", /DummyJob\s+Enqueued less than a minute ago\s+queue_1\s+in 3 minutes/
+    end
+  end
 end


### PR DESCRIPTION
## Summary

As reported in #136, we could have a mix of translations when this `default_locale` is set to another language than English.

This PR resolves this by adding a `around_action` that set's the locale to English during the execution of the action.

I've also removed a docker volume and the `version` from the `docker-compose.yml` because the volume isn't being used, and the version is obsolete.

Fixes #136

### Before

<img width="923" alt="SCR-20240703-lyvd" src="https://github.com/rails/mission_control-jobs/assets/331876/424c16f5-d642-4213-9b27-cfe5d6292dea">

### After

<img width="879" alt="image" src="https://github.com/rails/mission_control-jobs/assets/331876/4db0033f-291e-4785-a4df-640a7e2f259c">


