### PR TITLE
Relax dependency for Rails 8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
     mission_control-jobs (0.2.1)
       importmap-rails
       irb (~> 1.13)
-      rails (>= 7.1)
+      rails
       stimulus-rails
       turbo-rails
 
@@ -356,4 +356,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.5.7
+   2.5.6

--- a/mission_control-jobs.gemspec
+++ b/mission_control-jobs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 7.1"
+  spec.add_dependency "rails"
   spec.add_dependency "importmap-rails"
   spec.add_dependency "turbo-rails"
   spec.add_dependency "stimulus-rails"


### PR DESCRIPTION
I think it's better to remove the dependency constraint