### PR TITLE
Handle empty backtrace from Solid Queue failed execution

### DIFF
--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -118,7 +118,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
         ActiveJob::ExecutionError.new \
           error_class: solid_queue_job.failed_execution.exception_class,
           message: solid_queue_job.failed_execution.message,
-          backtrace: solid_queue_job.failed_execution.backtrace
+          backtrace: solid_queue_job.failed_execution.backtrace || []
       end
     end
 


### PR DESCRIPTION
This happens if we have to mark a job as failed because the worker processing it died. There won't be a proper backtrace in the exception in that case.

Related: https://github.com/rails/solid_queue/pull/277