### PR TITLE
Use a supported locale for localization

### DIFF
--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -20,6 +20,6 @@ class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_co
     end
 
     def set_current_locale(&block)
-      I18n.with_locale(:en, &block)
+      I18n.with_locale(I18n.available_locales.sort.find { |locale| locale.start_with?("en") } || I18n.default_locale, &block)
     end
 end


### PR DESCRIPTION
The changes in #137 causes the exception `I18n::InvalidLocale: :en is not a valid locale` to be raised if the application doesn't support the `en` locale.
It could be that the application uses `en-US` instead or maybe an English locale isn't available at all.

This change fixes the exception by looking for English based locales and will fallback to I18n.default_locale if none is found.
Sorting the locales ensure that `en` is used if it is available.