### PR TITLE
Redirect back after discarding a job

### DIFF
--- a/app/controllers/mission_control/jobs/discards_controller.rb
+++ b/app/controllers/mission_control/jobs/discards_controller.rb
@@ -3,7 +3,7 @@ class MissionControl::Jobs::DiscardsController < MissionControl::Jobs::Applicati
 
   def create
     @job.discard
-    redirect_to application_jobs_url(@application, :failed), notice: "Discarded job with id #{@job.job_id}"
+    redirect_back fallback_location: application_jobs_url(@application, :failed), notice: "Discarded job with id #{@job.job_id}"
   end
 
   private


### PR DESCRIPTION
Discarding a job can currently be done from "Failed jobs" and "Scheduled jobs" pages, but, as a result, the user is always redirected to "Failed jobs" page.

This change will make the user be redirected back instead.