### PR TITLE
Encapsulate Importmap into the Gem itself

### DIFF
--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -9,7 +9,7 @@
   <meta name="turbo-cache-control" content="no-cache">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
   <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
-  <%= javascript_importmap_tags "application-mcj" %>
+  <%= javascript_importmap_tags "application", importmap: MissionControl::Jobs.importmap  %>
 </head>
 <body>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,4 +1,4 @@
-pin "application-mcj", to: "mission_control/jobs/application.js", preload: true
+pin "application", to: "mission_control/jobs/application.js", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true

--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -19,5 +19,6 @@ module MissionControl
     mattr_accessor :internal_query_count_limit, default: 500_000 # Hard limit to keep unlimited count queries fast enough
     mattr_accessor :show_console_help, default: true
     mattr_accessor :scheduled_job_delay_threshold, default: 1.minute
+    mattr_accessor :importmap, default: Importmap::Map.new
   end
 end

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -95,9 +95,13 @@ module MissionControl
         app.config.assets.precompile += %w[ mission_control_jobs_manifest ]
       end
 
-      initializer "mission_control-jobs.importmap", before: "importmap" do |app|
-        app.config.importmap.paths << root.join("config/importmap.rb")
-        app.config.importmap.cache_sweepers << root.join("app/javascript")
+      initializer "mission_control-jobs.importmap", after: "importmap" do |app|
+        MissionControl::Jobs.importmap.draw(root.join("config/importmap.rb"))
+        MissionControl::Jobs.importmap.cache_sweeper(watches: root.join("app/javascript"))
+
+        ActiveSupport.on_load(:action_controller_base) do
+          before_action { MissionControl::Jobs.importmap.cache_sweeper.execute_if_updated }
+        end
       end
     end
   end


### PR DESCRIPTION
This is based upon the importmap usage seen in ActiveAdmin.

This gem essentially provides a complete Application and as such it makes sense to have the importmap separate from the application it is embedded into.

There is a 0% chance of the javascript included here to be used outside of the gem itself.

It is still possible to extend the importmap if that is needed.

``` rb
MissionControl::Jobs.importmap.draw do
  pin "something"
end
```