### PR TITLE
Add "Next run" column to recurring tasks index

### DIFF
--- a/app/models/mission_control/jobs/recurring_task.rb
+++ b/app/models/mission_control/jobs/recurring_task.rb
@@ -1,7 +1,7 @@
 class MissionControl::Jobs::RecurringTask
   include ActiveModel::Model
 
-  attr_accessor :id, :job_class_name, :command, :arguments, :schedule, :last_enqueued_at, :queue_name, :priority
+  attr_accessor :id, :job_class_name, :command, :arguments, :schedule, :last_enqueued_at, :next_time, :queue_name, :priority
 
   def initialize(queue_adapter: ActiveJob::Base.queue_adapter, **kwargs)
     @queue_adapter = queue_adapter

--- a/app/views/mission_control/jobs/recurring_tasks/_recurring_task.html.erb
+++ b/app/views/mission_control/jobs/recurring_tasks/_recurring_task.html.erb
@@ -15,4 +15,5 @@
   </td>
   <td> <%= recurring_task.schedule %> </td>
   <td><div class="has-text-grey"><%= recurring_task.last_enqueued_at ? bidirectional_time_distance_in_words_with_title(recurring_task.last_enqueued_at) : "Never" %></div></td>
+  <td class="next_time"><div class="has-text-grey"><%= bidirectional_time_distance_in_words_with_title(recurring_task.next_time) %></div></td>
 </tr>

--- a/app/views/mission_control/jobs/recurring_tasks/index.html.erb
+++ b/app/views/mission_control/jobs/recurring_tasks/index.html.erb
@@ -8,6 +8,7 @@
     <th>Job</th>
     <th>Schedule</th>
     <th>Last enqueued at</th>
+    <th>Next run</th>
   </tr>
   </thead>
 

--- a/lib/active_job/queue_adapters/solid_queue_ext/recurring_tasks.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext/recurring_tasks.rb
@@ -28,6 +28,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt::RecurringTasks
         command: task.command,
         arguments: task.arguments,
         schedule: task.schedule,
+        next_time: task.next_time,
         queue_name: task.queue_name,
         priority: task.priority
       }

--- a/test/controllers/recurring_tasks_controller_test.rb
+++ b/test/controllers/recurring_tasks_controller_test.rb
@@ -22,6 +22,7 @@ class MissionControl::Jobs::RecurringTasksControllerTest < ActionDispatch::Integ
       assert_select "td", "PauseJob"
       assert_select "td", "every second"
       assert_select "td", /less than \d+ seconds ago/
+      assert_select "td.next_time", /less than \d+ seconds ago/
     end
   end
 


### PR DESCRIPTION
This change adds a "Next run" column to the Recurring Tasks index page, which indicates when the job will next be enqueued. This is a feature that I got used to when using GoodJob, and I found I missed in Mission Control.

I'd be happy to hear feedback on the idea or the implementation. Thanks!