### PR TITLE
Move inline styles to stylesheet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,13 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.7)
     builder (3.2.4)
     concurrent-ruby (1.3.3)
@@ -307,6 +314,7 @@ GEM
       rack-protection (= 4.0.0)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -351,6 +359,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  better_html
   capybara!
   debug
   mission_control-jobs!

--- a/app/assets/stylesheets/mission_control/jobs/jobs.css
+++ b/app/assets/stylesheets/mission_control/jobs/jobs.css
@@ -2,6 +2,35 @@
     width: 15rem;
 }
 
-.jobs td {
-    word-break: break-all;
+table.jobs {
+    td {
+        word-break: break-all;
+    }
+    th.job-header{
+        width: 30%;
+    }
+    th.duration-header {
+        width: 20%;
+    }
+    &.queues th.job-header {
+        width: 30%;
+    }
+    &.failed th.job-header {
+        width: 35%;
+    }
+    &.in_progress th.job-header {
+        width: 50%;
+    }
+    &.blocked th.job-header {
+        width: 45%;
+    }
+    &.scheduled th.job-header {
+        width: 60%;
+    }
+    &.finished th.job-header {
+        width: 65%;
+    }
+    &.workers th.job-header {
+        width: 40%;
+    }
 }

--- a/app/views/mission_control/jobs/jobs/_filters.html.erb
+++ b/app/views/mission_control/jobs/jobs/_filters.html.erb
@@ -14,13 +14,13 @@
 
         <%= hidden_field_tag :server_id, MissionControl::Jobs::Current.server.id %>
 
-        <datalist id="job-classes" style="display: none;">
+        <datalist id="job-classes" class="is-hidden">
           <% job_class_names.each do |job_class_name| %>
             <option value="<%= job_class_name %>" />
           <% end %>
         </datalist>
 
-        <datalist id="queue-names" style="display: none;">
+        <datalist id="queue-names" class="is-hidden">
           <% queue_names.each do |queue_name| %>
             <option value="<%= queue_name %>" />
           <% end %>

--- a/app/views/mission_control/jobs/jobs/_jobs_page.html.erb
+++ b/app/views/mission_control/jobs/jobs/_jobs_page.html.erb
@@ -1,7 +1,7 @@
 <table class="jobs <%= jobs_status %> table queues is-hoverable is-fullwidth">
   <thead>
     <tr>
-      <th style="width: 35%;">Job</th>
+      <th class="job-header">Job</th>
       <% attribute_names_for_job_status(jobs_status).each do |attribute| %>
         <th><%= attribute %></th>
       <% end %>

--- a/app/views/mission_control/jobs/queues/index.html.erb
+++ b/app/views/mission_control/jobs/queues/index.html.erb
@@ -4,8 +4,8 @@
   <tbody>
   <thead>
   <tr>
-    <th style="width: 50%;">Queue</th>
-    <th style="width: 30%;">Pending jobs</th>
+    <th>Queue</th>
+    <th>Pending jobs</th>
     <th></th>
   </tr>
   </thead>

--- a/app/views/mission_control/jobs/queues/show.html.erb
+++ b/app/views/mission_control/jobs/queues/show.html.erb
@@ -9,7 +9,7 @@
     <tbody>
     <thead>
     <tr>
-      <th style="width: 30%;">Job</th>
+      <th class="job-header">Job</th>
       <th></th>
     </tr>
     </thead>

--- a/app/views/mission_control/jobs/shared/_jobs.html.erb
+++ b/app/views/mission_control/jobs/shared/_jobs.html.erb
@@ -2,9 +2,9 @@
   <tbody>
   <thead>
   <tr>
-    <th style="width: 30%;">Job</th>
+    <th class="job-header">Job</th>
     <th></th>
-    <th style="width: 20%;"></th>
+    <th class="duration-header"></th>
   </tr>
   </thead>
 

--- a/app/views/mission_control/jobs/workers/_workers_page.html.erb
+++ b/app/views/mission_control/jobs/workers/_workers_page.html.erb
@@ -4,7 +4,7 @@
   <tr>
     <th>Worker</th>
     <th>Hostname</th>
-    <th style="width: 35%;">Jobs</th>
+    <th class="job-header">Jobs</th>
     <th>Last heartbeat</th>
   </tr>
   </thead>

--- a/mission_control-jobs.gemspec
+++ b/mission_control-jobs.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.52.0"
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rails-omakase"
+  spec.add_development_dependency "better_html"
   spec.add_development_dependency "sprockets-rails"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "puma"

--- a/test/mission_control/erb_inline_styles_test.rb
+++ b/test/mission_control/erb_inline_styles_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "better_html"
+require "better_html/parser"
+require "better_html/tree/tag"
+
+class MissionControl::ErbInlineStylesTest < ActiveSupport::TestCase
+  ERB_GLOB = Rails.root.join(
+    "..", "..", "app", "views", "**", "{*.htm,*.html,*.htm.erb,*.html.erb,*.html+*.erb}"
+  )
+
+  Dir[ERB_GLOB].each do |filename|
+    pathname = Pathname.new(filename).relative_path_from(Rails.root)
+
+    test "No inline styles in /#{pathname.relative_path_from('../..')}" do
+      buffer = Parser::Source::Buffer.new("")
+      buffer.source = File.read(filename)
+      parser = BetterHtml::Parser.new(buffer)
+
+      parser.nodes_with_type(:tag).each do |tag_node|
+        tag = BetterHtml::Tree::Tag.from_node(tag_node)
+        assert_nil tag.attributes["style"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Inline styles violate the default Content Security Policy generated by Rails. I also made it so that the jobs column is larger on tables with more space.

```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    policy.default_src :self, :https
    policy.font_src    :self, :https, :data
    policy.img_src     :self, :https, :data
    policy.object_src  :none
    policy.script_src  :self, :https
    policy.style_src   :self, :https
    # Specify URI for violation reports
    # policy.report_uri "/csp-violation-report-endpoint"
  end

  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
  config.content_security_policy_nonce_directives = %w[script-src style-src]

  # Report violations without enforcing the policy.
  # config.content_security_policy_report_only = true
end
```

![image](https://github.com/user-attachments/assets/284e9baa-5735-4b55-86ef-332acd858fc2)
