### PR TITLE
Add prefix to JS assets

### DIFF
--- a/app/javascript/mission_control/jobs/application.js
+++ b/app/javascript/mission_control/jobs/application.js
@@ -1,4 +1,3 @@
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
-import "controllers"
-import "helpers"
+import "mcj-@hotwired/turbo-rails"
+import "mcj-controllers"
+import "mcj-helpers"

--- a/app/javascript/mission_control/jobs/controllers/index.js
+++ b/app/javascript/mission_control/jobs/controllers/index.js
@@ -1,11 +1,4 @@
-// Import and register all your controllers from the importmap under controllers/*
+import { application } from "mcj-controllers/application"
+import { eagerLoadControllersFrom } from "mcj-@hotwired/stimulus-loading"
 
-import { application } from "controllers/application"
-
-// Eager load all controllers defined in the import map under controllers/**/*_controller
-import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)
-
-// Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
-// import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
-// lazyLoadControllersFrom("controllers", application)

--- a/app/javascript/mission_control/jobs/helpers/index.js
+++ b/app/javascript/mission_control/jobs/helpers/index.js
@@ -1,1 +1,1 @@
-export * from "helpers/debounce_helpers"
+export * from "mcj-helpers/debounce_helpers"

--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -9,7 +9,7 @@
   <meta name="turbo-cache-control" content="no-cache">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.1/css/bulma.min.css">
   <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
-  <%= javascript_importmap_tags "application-mcj" %>
+  <%= javascript_importmap_tags "mcj" %>
 </head>
 <body>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,15 @@
-pin "application-mcj", to: "mission_control/jobs/application.js", preload: true
-pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
-pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
-pin_all_from MissionControl::Jobs::Engine.root.join("app/javascript/mission_control/jobs/controllers"), under: "controllers", to: "mission_control/jobs/controllers"
-pin_all_from MissionControl::Jobs::Engine.root.join("app/javascript/mission_control/jobs/helpers"), under: "helpers", to: "mission_control/jobs/helpers"
+with_options preload: "mcj" do
+  pin "mcj", to: "mission_control/jobs/application.js"
+
+  pin "mcj-@hotwired/turbo-rails", to: "turbo.min.js"
+  pin "mcj-@hotwired/stimulus", to: "stimulus.min.js"
+  pin "mcj-@hotwired/stimulus-loading", to: "stimulus-loading.js"
+
+  pin_all_from MissionControl::Jobs::Engine.root.join("app/javascript/mission_control/jobs/controllers"),
+    under: "mcj-controllers",
+    to: "mission_control/jobs/controllers"
+
+  pin_all_from MissionControl::Jobs::Engine.root.join("app/javascript/mission_control/jobs/helpers"),
+    under: "mcj-helpers",
+    to: "mission_control/jobs/helpers"
+end


### PR DESCRIPTION
I noticed that MCJ overwrites some of my app's importmap includes, e.g.

`"controllers": "https://myapp.com/assets/controllers/index-be0771f7.js"`

becomes

`"controllers": "https://myapp.com/assets/mission_control/jobs/controllers/index-77c24c3f.js"`

after including this gem.

This PR fixes that by prefixing all JS assets with "mcj-" and preloading them only when the "mcj" entry point is loaded.

