### PR TITLE
Short navigation jobs count

### DIFF
--- a/app/helpers/mission_control/jobs/navigation_helper.rb
+++ b/app/helpers/mission_control/jobs/navigation_helper.rb
@@ -47,6 +47,18 @@ module MissionControl::Jobs::NavigationHelper
 
   def jobs_count_with_status(status)
     count = ActiveJob.jobs.with_status(status).count
-    count.infinite? ? "..." : number_to_human(count)
+    if count.infinite?
+      "..."
+    else
+      number_to_human(count,
+        format: "%n%u",
+        units: {
+          thousand: "K",
+          million: "M",
+          billion: "B",
+          trillion: "T",
+          quadrillion: "Q"
+        })
+    end
   end
 end


### PR DESCRIPTION
This patch defines the `number_to_human` format and units option to make the navigation section titles more compact and readable.

As an example, instead of "Finished Jobs (4.4 Thousand)" it will now display "Finished Jobs (4.4K)".

https://api.rubyonrails.org/classes/ActiveSupport/NumberHelper.html#method-i-number_to_human

Before:
<img width="1210" alt="Screenshot 2024-10-14 at 17 34 58" src="https://github.com/user-attachments/assets/23458848-ecac-42a4-a3e7-9306b9e7d820">

After:
<img width="1218" alt="Screenshot 2024-10-14 at 17 35 17" src="https://github.com/user-attachments/assets/3171aa11-3602-4c58-ba8f-a053d23c4702">