### PR TITLE
Stop connecting to an application by default in the console

### DIFF
--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -77,11 +77,6 @@ module MissionControl
         MissionControl::Jobs.delay_between_bulk_operation_batches = 2
         MissionControl::Jobs.logger = ActiveSupport::Logger.new(STDOUT)
 
-        if MissionControl::Jobs.applications.one? && (application = MissionControl::Jobs.applications.first) && application.servers.one?
-          MissionControl::Jobs::Current.application = application
-          MissionControl::Jobs::Current.server = application.servers.first
-        end
-
         if MissionControl::Jobs.show_console_help
           puts "\n\nType 'jobs_help' to see how to connect to the available job servers to manage jobs\n\n"
         end


### PR DESCRIPTION
This will mess up enqueuing jobs from the console when using multiple adapters because of being in the middle of a migration, and only configuring one of them for Mission Control (eg. migrating from Sidekiq to Solid Queue). It's also not necessary because if we don't have a current server set, [we just don't call `activating`](https://github.com/rails/mission_control-jobs/blob/9923a745ad5076300de1081e0b76e0f5b0e61bc4/lib/mission_control/jobs/console/context.rb#L8) and rely [on the queue adapter configured for the job we want to enqueue](https://github.com/rails/mission_control-jobs/blob/9923a745ad5076300de1081e0b76e0f5b0e61bc4/lib/active_job/executing.rb#L14-L16) (which might be per-job or the one set globally as `config.active_job.queue_adapter`). 

Fixes #174