### PR TITLE
Simplify all times shown to not use any words, just exact numbers

### DIFF
--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -4,14 +4,8 @@ class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_co
   include MissionControl::Jobs::ApplicationScoped, MissionControl::Jobs::NotFoundRedirections
   include MissionControl::Jobs::AdapterFeatures
 
-  around_action :set_current_locale
-
   private
     def default_url_options
       { server_id: MissionControl::Jobs::Current.server }
-    end
-
-    def set_current_locale(&block)
-      I18n.with_locale(:en, &block)
     end
 end

--- a/app/helpers/mission_control/jobs/dates_helper.rb
+++ b/app/helpers/mission_control/jobs/dates_helper.rb
@@ -1,19 +1,5 @@
 module MissionControl::Jobs::DatesHelper
-  def time_ago_in_words_with_title(time)
-    tag.span time_ago_in_words(time), title: time.to_fs(:long)
-  end
-
-  def time_distance_in_words_with_title(time)
-    tag.span distance_of_time_in_words_to_now(time, include_seconds: true), title: "Since #{time.to_fs(:long)}"
-  end
-
-  def bidirectional_time_distance_in_words_with_title(time)
-    time_distance = if time.past?
-      "#{distance_of_time_in_words_to_now(time, include_seconds: true)} ago"
-    else
-      "in #{distance_of_time_in_words_to_now(time, include_seconds: true)}"
-    end
-
-    tag.span time_distance, title: time.to_fs(:long)
+  def formatted_time(time)
+    time.strftime("%Y-%m-%d %H:%M:%S.%3N")
   end
 end

--- a/app/helpers/mission_control/jobs/jobs_helper.rb
+++ b/app/helpers/mission_control/jobs/jobs_helper.rb
@@ -29,7 +29,7 @@ module MissionControl::Jobs::JobsHelper
     when "blocked"     then [ "Queue", "Blocked by", "Block expiry", "" ]
     when "finished"    then [ "Queue", "Finished" ]
     when "scheduled"   then [ "Queue", "Scheduled", "" ]
-    when "in_progress" then [ "Queue", "Run by", "Running for" ]
+    when "in_progress" then [ "Queue", "Run by", "Running since" ]
     else               []
     end
   end

--- a/app/views/mission_control/jobs/jobs/_general_information.html.erb
+++ b/app/views/mission_control/jobs/jobs/_general_information.html.erb
@@ -23,14 +23,14 @@
   <tr>
     <th>Enqueued</th>
     <td>
-      <%= time_ago_in_words_with_title(job.enqueued_at.to_datetime) %> ago
+      <%= formatted_time(job.enqueued_at.to_datetime) %>
     </td>
   </tr>
   <% if job.failed? %>
     <tr>
       <th>Failed</th>
       <td>
-        <%= time_ago_in_words_with_title(job.failed_at) %> ago
+        <%= formatted_time(job.failed_at) %>
       </td>
     </tr>
   <% end %>
@@ -38,7 +38,7 @@
     <tr>
       <th>Finished at</th>
       <td>
-        <%= time_ago_in_words_with_title(job.finished_at) %> ago
+        <%= formatted_time(job.finished_at) %>
       </td>
     </tr>
   <% end %>

--- a/app/views/mission_control/jobs/jobs/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/_job.html.erb
@@ -6,7 +6,7 @@
       <div class="is-family-monospace"><%= job_arguments(job) %></div>
     <% end %>
 
-    <div class="has-text-grey is-size-7">Enqueued <%= time_ago_in_words_with_title(job.enqueued_at.to_datetime) %> ago</div>
+    <div class="has-text-grey is-size-7">Enqueued <%= formatted_time(job.enqueued_at.to_datetime) %></div>
   </td>
 
   <%= render "mission_control/jobs/jobs/#{jobs_status}/job", job: job %>

--- a/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
@@ -1,6 +1,6 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td><div class="is-family-monospace is-size-7"><%= job.blocked_by %></div></td>
-<td><%= bidirectional_time_distance_in_words_with_title(job.blocked_until) %></td>
+<td><%= formatted_time(job.blocked_until) %></td>
 <td class="pr-0">
   <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>
 </td>

--- a/app/views/mission_control/jobs/jobs/failed/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/failed/_job.html.erb
@@ -1,6 +1,6 @@
 <td>
   <%= link_to failed_job_error(job), application_job_path(@application, job.job_id, anchor: "error") %>
-  <div class="has-text-grey"><%= time_ago_in_words_with_title(job.failed_at) %> ago</div>
+  <div class="has-text-grey"><%= formatted_time(job.failed_at) %></div>
 </td>
 <td class="pr-0">
   <%= render "mission_control/jobs/jobs/failed/actions", job: job %>

--- a/app/views/mission_control/jobs/jobs/finished/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/finished/_job.html.erb
@@ -1,2 +1,2 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
-<td><div class="has-text-grey"><%= time_ago_in_words_with_title(job.finished_at) %> ago</div></td>
+<td><div class="has-text-grey"><%= formatted_time(job.finished_at) %></div></td>

--- a/app/views/mission_control/jobs/jobs/in_progress/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/in_progress/_job.html.erb
@@ -6,4 +6,4 @@
     —
   <% end %>
 </td>
-<td><div class="has-text-grey"><%= job.started_at ? time_distance_in_words_with_title(job.started_at) : "(Finished)" %></div></td>
+<td><div class="has-text-grey"><%= job.started_at ? formatted_time(job.started_at) : "(Finished)" %></div></td>

--- a/app/views/mission_control/jobs/jobs/scheduled/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/scheduled/_job.html.erb
@@ -1,6 +1,6 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td>
-  <%= bidirectional_time_distance_in_words_with_title(job.scheduled_at) %>
+  <%= formatted_time(job.scheduled_at) %>
   <% if job_delayed?(job) %>
     <div class="is-danger tag ml-4">delayed</div>
   <% end %>

--- a/app/views/mission_control/jobs/queues/_job.html.erb
+++ b/app/views/mission_control/jobs/queues/_job.html.erb
@@ -3,7 +3,7 @@
     <%= link_to application_job_path(@application, job.job_id, filter: { queue_name: job.queue }) do %>
       <%= job_title(job) %>
     <% end %>
-    <div class="has-text-grey">Enqueued <%= time_ago_in_words_with_title(job.enqueued_at.to_datetime) %> ago</div>
+    <div class="has-text-grey">Enqueued on <%= formatted_time(job.enqueued_at.to_datetime) %></div>
   </td>
   <td>
     <% if job.serialized_arguments.present? %>

--- a/app/views/mission_control/jobs/recurring_tasks/_recurring_task.html.erb
+++ b/app/views/mission_control/jobs/recurring_tasks/_recurring_task.html.erb
@@ -14,5 +14,5 @@
     <% end %>
   </td>
   <td> <%= recurring_task.schedule %> </td>
-  <td><div class="has-text-grey"><%= recurring_task.last_enqueued_at ? bidirectional_time_distance_in_words_with_title(recurring_task.last_enqueued_at) : "Never" %></div></td>
+  <td><div class="has-text-grey"><%= recurring_task.last_enqueued_at ? formatted_time(recurring_task.last_enqueued_at) : "Never" %></div></td>
 </tr>

--- a/app/views/mission_control/jobs/shared/_job.html.erb
+++ b/app/views/mission_control/jobs/shared/_job.html.erb
@@ -3,7 +3,7 @@
     <%= link_to application_job_path(@application, job.job_id, filter: { queue_name: job.queue }) do %>
       <%= job_title(job) %>
     <% end %>
-    <div class="has-text-grey">Enqueued <%= time_ago_in_words_with_title(job.enqueued_at.to_datetime) %> ago</div>
+    <div class="has-text-grey">Enqueued on <%= formatted_time(job.enqueued_at.to_datetime) %></div>
   </td>
   <td>
     <% if job.serialized_arguments.present? %>
@@ -16,9 +16,9 @@
   <td>
     <div class="has-text-grey">
       <% if job.started_at %>
-        Running for <%= time_distance_in_words_with_title(job.started_at) %>
+        Running since <%= formatted_time(job.started_at) %>
       <% elsif job.finished_at %>
-        Finished <%= time_ago_in_words_with_title(job.finished_at) %> ago
+        Finished on <%= formatted_time(job.finished_at) %>
       <% else %>
         Pending
       <% end %>

--- a/app/views/mission_control/jobs/workers/_worker.html.erb
+++ b/app/views/mission_control/jobs/workers/_worker.html.erb
@@ -17,5 +17,5 @@
     <% end %>
   </td>
 
-  <td><div class="has-text-grey"><%= time_ago_in_words_with_title(worker.last_heartbeat_at) %> ago</div></td>
+  <td><div class="has-text-grey"><%= formatted_time(worker.last_heartbeat_at) %></div></td>
 </tr>

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -24,6 +24,7 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "get jobs and job details when there are multiple instances of the same job due to automatic retries" do
+    time = Time.now
     job = AutoRetryingJob.perform_later
 
     perform_enqueued_jobs_async
@@ -32,7 +33,7 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
 
     assert_select "tr.job", 2
-    assert_select "tr.job", /AutoRetryingJob\s+Enqueued less than a minute ago\s+default/
+    assert_select "tr.job", /AutoRetryingJob\s+Enqueued #{time_pattern(time)}\s+default/
 
     get mission_control_jobs.application_job_url(@application, job.job_id)
     assert_response :ok
@@ -50,17 +51,16 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "get scheduled jobs" do
+    time = Time.now
     DummyJob.set(wait: 3.minutes).perform_later
     DummyJob.set(wait: 1.minute).perform_later
-
-    travel_to 2.minutes.from_now
 
     get mission_control_jobs.application_jobs_url(@application, :scheduled)
     assert_response :ok
 
     assert_select "tr.job", 2
-    assert_select "tr.job", /DummyJob\s+Enqueued 2 minutes ago\s+queue_1\s+in 1 minute/
-    assert_select "tr.job", /DummyJob\s+Enqueued 2 minutes ago\s+queue_1\s+(1 minute ago|less than a minute ago)/
+    assert_select "tr.job", /DummyJob\s+Enqueued #{time_pattern(time)}\s+queue_1\s+#{time_pattern(time + 3.minute)}/
+    assert_select "tr.job", /DummyJob\s+Enqueued #{time_pattern(time)}\s+queue_1\s+#{time_pattern(time + 1.minute)}/
     assert_select "tr.job", /Discard/
   end
 
@@ -83,16 +83,8 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "get jobs and job details the default locale is set to another language than English" do
-    I18n.available_locales = %i[en nl]
-
-    DummyJob.set(wait: 3.minutes).perform_later
-
-    I18n.with_locale(:nl) do
-      get mission_control_jobs.application_jobs_url(@application, :scheduled)
-      assert_response :ok
-
-      assert_select "tr.job", /DummyJob\s+Enqueued less than a minute ago\s+queue_1\s+in 3 minutes/
+  private
+    def time_pattern(time)
+      /#{time.utc.strftime("%Y-%m-%d %H:%M")}:\d{2}\.\d{3}/
     end
-  end
 end

--- a/test/controllers/recurring_tasks_controller_test.rb
+++ b/test/controllers/recurring_tasks_controller_test.rb
@@ -13,28 +13,32 @@ class MissionControl::Jobs::RecurringTasksControllerTest < ActionDispatch::Integ
   end
 
   test "get recurring task list" do
-    schedule_recurring_tasks_async(wait: 2.seconds) do
-      get mission_control_jobs.application_recurring_tasks_url(@application)
-      assert_response :ok
+    travel_to Time.parse("2024-10-30 19:07:10 UTC") do
+      schedule_recurring_tasks_async(wait: 2.seconds) do
+        get mission_control_jobs.application_recurring_tasks_url(@application)
+        assert_response :ok
 
-      assert_select "tr.recurring_task", 1
-      assert_select "td a", "periodic_pause_job"
-      assert_select "td", "PauseJob"
-      assert_select "td", "every second"
-      assert_select "td", /less than \d+ seconds ago/
+        assert_select "tr.recurring_task", 1
+        assert_select "td a", "periodic_pause_job"
+        assert_select "td", "PauseJob"
+        assert_select "td", "every second"
+        assert_select "td", /2024-10-30 19:07:1\d\.\d{3}/
+      end
     end
   end
 
   test "get recurring task details and job list" do
-    schedule_recurring_tasks_async(wait: 1.seconds) do
-      get mission_control_jobs.application_recurring_task_url(@application, "periodic_pause_job")
-      assert_response :ok
+    travel_to Time.parse("2024-10-30 19:07:10 UTC") do
+      schedule_recurring_tasks_async(wait: 1.seconds) do
+        get mission_control_jobs.application_recurring_task_url(@application, "periodic_pause_job")
+        assert_response :ok
 
-      assert_select "h1", /periodic_pause_job/
-      assert_select "h2", "1 job"
-      assert_select "tr.job", 1
-      assert_select "td a", "PauseJob"
-      assert_select "td div", /Enqueued less than a minute ago/
+        assert_select "h1", /periodic_pause_job/
+        assert_select "h2", "1 job"
+        assert_select "tr.job", 1
+        assert_select "td a", "PauseJob"
+        assert_select "td", /2024-10-30 19:07:1\d\.\d{3}/
+      end
     end
   end
 

--- a/test/controllers/retries_controller_test.rb
+++ b/test/controllers/retries_controller_test.rb
@@ -10,21 +10,23 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "retry jobs when there are multiple instances of the same job due to automatic retries" do
-    job = AutoRetryingJob.perform_later
+    travel_to Time.parse("2024-10-30 19:07:10 UTC") do
+      job = AutoRetryingJob.perform_later
 
-    perform_enqueued_jobs_async
+      perform_enqueued_jobs_async
 
-    get mission_control_jobs.application_jobs_url(@application, :failed)
-    assert_response :ok
+      get mission_control_jobs.application_jobs_url(@application, :failed)
+      assert_response :ok
 
-    assert_select "tr.job", 1
-    assert_select "tr.job", /AutoRetryingJob\s+Enqueued less than a minute ago\s+AutoRetryingJob::RandomError/
+      assert_select "tr.job", 1
+      assert_select "tr.job", /AutoRetryingJob\s+Enqueued 2024-10-30 19:07:1\d\.\d{3}\s+AutoRetryingJob::RandomError/
 
-    post mission_control_jobs.application_job_retry_url(@application, job.job_id)
-    assert_redirected_to mission_control_jobs.application_jobs_url(@application, :failed)
-    follow_redirect!
+      post mission_control_jobs.application_job_retry_url(@application, job.job_id)
+      assert_redirected_to mission_control_jobs.application_jobs_url(@application, :failed)
+      follow_redirect!
 
-    assert_select "article.is-danger", text: /Job with id '#{job.job_id}' not found/, count: 0
-    assert_select "tr.job", 0
+      assert_select "article.is-danger", text: /Job with id '#{job.job_id}' not found/, count: 0
+      assert_select "tr.job", 0
+    end
   end
 end

--- a/test/system/discard_jobs_test.rb
+++ b/test/system/discard_jobs_test.rb
@@ -2,9 +2,9 @@ require_relative "../application_system_test_case"
 
 class DiscardJobsTest < ApplicationSystemTestCase
   setup do
-    4.times { |index| FailingJob.set(queue: "queue_1").perform_later(index) }
-    3.times { |index| FailingReloadedJob.set(queue: "queue_2").perform_later(4 + index) }
-    2.times { |index| FailingJob.set(queue: "queue_2").perform_later(7 + index) }
+    4.times { |index| FailingJob.set(queue: "queue_1").perform_later("failing-arg-#{index}") }
+    3.times { |index| FailingReloadedJob.set(queue: "queue_2").perform_later("failing-reloaded-arg-#{4 + index}") }
+    2.times { |index| FailingJob.set(queue: "queue_2").perform_later("failing-arg-#{7 + index}") }
     perform_enqueued_jobs
 
     visit jobs_path(:failed)
@@ -25,7 +25,7 @@ class DiscardJobsTest < ApplicationSystemTestCase
     assert_equal 9, job_row_elements.length
     expected_job_id = ActiveJob.jobs.failed[2].job_id
 
-    within_job_row "2" do
+    within_job_row "failing-arg-2" do
       accept_confirm do
         click_on "Discard"
       end

--- a/test/system/retry_jobs_test.rb
+++ b/test/system/retry_jobs_test.rb
@@ -2,9 +2,10 @@ require_relative "../application_system_test_case"
 
 class RetryJobsTest < ApplicationSystemTestCase
   setup do
-    4.times { |index| FailingJob.set(queue: "queue_1").perform_later(index) }
-    3.times { |index| FailingReloadedJob.set(queue: "queue_2").perform_later(4 + index) }
-    2.times { |index| FailingJob.set(queue: "queue_2").perform_later(7 + index) }
+    4.times { |index| FailingJob.set(queue: "queue_1").perform_later("failing-arg-#{index}") }
+    3.times { |index| FailingReloadedJob.set(queue: "queue_2").perform_later("failing-reloaded-arg-#{4 + index}") }
+    2.times { |index| FailingJob.set(queue: "queue_2").perform_later("failing-arg-#{7 + index}") }
+    perform_enqueued_jobs
     perform_enqueued_jobs
 
     visit jobs_path(:failed)
@@ -23,7 +24,7 @@ class RetryJobsTest < ApplicationSystemTestCase
     assert_equal 9, job_row_elements.length
     expected_job_id = ActiveJob.jobs.failed[2].job_id
 
-    within_job_row "2" do
+    within_job_row "failing-arg-2" do
       click_on "Retry"
     end
 

--- a/test/system/show_queue_job_test.rb
+++ b/test/system/show_queue_job_test.rb
@@ -3,7 +3,7 @@ require_relative "../application_system_test_case"
 class ShowQueueJobsTest < ApplicationSystemTestCase
   setup do
     DummyJob.queue_as :queue_1
-    10.times { |index| DummyJob.perform_later(index) }
+    10.times { |index| DummyJob.perform_later("dummy-arg-#{index}") }
 
     visit queues_path
   end
@@ -11,10 +11,10 @@ class ShowQueueJobsTest < ApplicationSystemTestCase
   test "click on a queue job to see its details" do
     click_on "queue_1"
 
-    within_job_row /2/ do
+    within_job_row /dummy-arg-2/ do
       click_on "DummyJob"
     end
 
-    assert_text /arguments\s*2/i
+    assert_text /arguments\s*dummy-arg-2/i
   end
 end


### PR DESCRIPTION
So everything is hardcoded to English, and we don't need to set a locale or have mixed-language phrases all over the place. Arguably, having the more "human-friendly" times such as "10 minutes ago" was not that useful in the end, when you're trying to get the exact time a job was enqueued to compare it with another time and so on. I found myself hovering over these times super often, so in this way, we just simplify the whole thing. 

This would fix the issue described in #156 and would avoid having to mess up with locales. 