### PR TITLE
Redirect to index page by status when discarding a job

### DIFF
--- a/app/controllers/mission_control/jobs/discards_controller.rb
+++ b/app/controllers/mission_control/jobs/discards_controller.rb
@@ -3,11 +3,16 @@ class MissionControl::Jobs::DiscardsController < MissionControl::Jobs::Applicati
 
   def create
     @job.discard
-    redirect_back fallback_location: application_jobs_url(@application, :failed), notice: "Discarded job with id #{@job.job_id}"
+    redirect_to redirect_location, notice: "Discarded job with id #{@job.job_id}"
   end
 
   private
     def jobs_relation
       ActiveJob.jobs.failed
+    end
+
+    def redirect_location
+      status = @job.status.presence_in(supported_job_statuses) || :failed
+      application_jobs_url(@application, status)
     end
 end

--- a/app/views/mission_control/jobs/jobs/_title.html.erb
+++ b/app/views/mission_control/jobs/jobs/_title.html.erb
@@ -11,6 +11,9 @@
       <% if job.blocked? %>
         <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>
       <% end %>
+      <% if job.scheduled? %>
+        <%= render "mission_control/jobs/jobs/scheduled/actions", job: job %>
+      <% end %>
     </div>
   </div>
 </h1>


### PR DESCRIPTION
This is a follow-up to #157, which redirected back after discarding instead of redirecting to the failed job page always, since you can discard a job from the scheduled jobs page as well. However, this doesn't work in the case of discarding a job from its individual page, because in that case we'd try to redirect to the job, and the job no longer exists, which results in a 404.

With this change, we just redirect to wherever the status of the discarded job is.