### PR TITLE
Stub adapter methods for async adapter

### DIFF
--- a/lib/active_job/queue_adapters/async_ext.rb
+++ b/lib/active_job/queue_adapters/async_ext.rb
@@ -1,0 +1,49 @@
+module ActiveJob::QueueAdapters::AsyncExt
+  include MissionControl::Jobs::Adapter
+
+  # List of filters supported natively. Non-supported filters are done in memory.
+  def supported_job_filters(jobs_relation)
+    []
+  end
+
+  def supports_queue_pausing?
+    false
+  end
+
+  def queues
+    []
+  end
+
+  def queue_size(*)
+    0
+  end
+
+  def clear_queue(*)
+  end
+
+  def jobs_count(*)
+    0
+  end
+
+  def fetch_jobs(*)
+    []
+  end
+
+  def retry_all_jobs(*)
+  end
+
+  def retry_job(job, *)
+  end
+
+  def discard_all_jobs(*)
+  end
+
+  def discard_job(*)
+  end
+
+  def dispatch_job(*)
+  end
+
+  def find_job(*)
+  end
+end

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -43,7 +43,7 @@ module MissionControl
           ActiveJob::QueueAdapters::SolidQueueAdapter.prepend ActiveJob::QueueAdapters::SolidQueueExt
         end
 
-        ActiveJob::QueueAdapters::AsyncAdapter.include MissionControl::Jobs::Adapter
+        ActiveJob::QueueAdapters::AsyncAdapter.include ActiveJob::QueueAdapters::AsyncExt
       end
 
       config.after_initialize do |app|

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -27,7 +27,7 @@ module Dummy
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # Mission Control supported adapters
-    config.mission_control.jobs.adapters = [ :resque, :solid_queue ]
+    # Mission Control configured adapters
+    config.mission_control.jobs.adapters = [ :resque, :solid_queue, :async ]
   end
 end


### PR DESCRIPTION
So that it doesn't crash when started for an app using the async adapter in development.

Closes #32