### PR TITLE
Improve rendering of job arguments

### DIFF
--- a/app/controllers/mission_control/jobs/jobs_controller.rb
+++ b/app/controllers/mission_control/jobs/jobs_controller.rb
@@ -15,7 +15,6 @@ class MissionControl::Jobs::JobsController < MissionControl::Jobs::ApplicationCo
   end
 
   private
-
     def jobs_relation
       filtered_jobs
     end

--- a/app/helpers/mission_control/jobs/jobs_helper.rb
+++ b/app/helpers/mission_control/jobs/jobs_helper.rb
@@ -39,7 +39,6 @@ module MissionControl::Jobs::JobsHelper
   end
 
   private
-
     def renderable_job_arguments_for(job)
       job.serialized_arguments.collect do |argument|
         as_renderable_argument(argument)
@@ -53,7 +52,7 @@ module MissionControl::Jobs::JobsHelper
       when Array
         as_renderable_array(argument)
       else
-        ActiveJob::Arguments.deserialize([ argument ])
+        ActiveJob::Arguments.deserialize([ argument ]).first
       end
     rescue ActiveJob::DeserializationError
       argument.to_s
@@ -65,12 +64,20 @@ module MissionControl::Jobs::JobsHelper
         argument["_aj_globalid"]
       elsif argument["_aj_serialized"] == "ActiveJob::Serializers::ModuleSerializer"
         argument["value"]
+      elsif argument["_aj_serialized"]
+        ActiveJob::Arguments.deserialize([ argument ]).first
       else
-        ActiveJob::Arguments.deserialize([ argument ])
+        to_symbols = argument.values_at("_aj_symbol_keys", "_aj_ruby2_keywords").compact.flatten
+        argument.without("_aj_symbol_keys", "_aj_ruby2_keywords")
+          .transform_values { |v| as_renderable_argument(v) }
+          .transform_keys { |k| k.to_sym if k.in? to_symbols }
+          .map { |k, v| "#{k}: #{v}" }
+          .join(", ")
+          .then { |s| "{#{s}}" }
       end
     end
 
     def as_renderable_array(argument)
-      "(#{argument.collect { |part| as_renderable_argument(part) }.join(", ")})"
+      "[#{argument.collect { |part| as_renderable_argument(part) }.join(", ")}]"
     end
 end

--- a/test/helpers/jobs_helper_test.rb
+++ b/test/helpers/jobs_helper_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class MissionControl::Jobs::JobsHelperTest < ActionView::TestCase
+  class JobWithRegularHashArguments < ApplicationJob
+    def perform(value, options)
+    end
+  end
+
+  class JobWithKeywordArgument < ApplicationJob
+    def perform(value, value_kwarg:)
+    end
+  end
+
+  class JobWithMultipleTypeArguments < ApplicationJob
+    def perform(value, options = {}, **kwargs)
+    end
+  end
+
+  setup do
+    @post = Post.create!(title: "test")
+    @datetime = Time.parse("2024-10-08 12:30:00 UTC")
+  end
+
+  test "render job arguments" do
+    assert_rendered_as \
+      "10, {datetime: 2024-10-08 12:30:00 UTC}",
+      JobWithRegularHashArguments, 10, datetime: @datetime
+
+    assert_rendered_as \
+      "2024-10-08 12:30:00 UTC, {number: 10, string: hola, class: ApplicationJob}",
+      JobWithRegularHashArguments, @datetime, number: 10, string: "hola", class: ApplicationJob
+
+    assert_rendered_as \
+      "#{@post.to_gid}, {array: [1, 2, 3]}",
+      JobWithRegularHashArguments, @post, array: [ 1, 2, 3 ]
+
+    assert_rendered_as \
+      "[1, 2, 3], {post: #{@post.to_gid}}",
+      JobWithRegularHashArguments, [ 1, 2, 3 ], post: @post
+
+    assert_rendered_as \
+      "{nested: {post: gid://dummy/Post/1}}, {post: gid://dummy/Post/1}",
+      JobWithRegularHashArguments, { nested: { post: @post } }, post: @post
+
+    assert_rendered_as \
+      "gid://dummy/Post/1, {nested: {post: gid://dummy/Post/1, datetime: 2024-10-08 12:30:00 UTC}}",
+      JobWithRegularHashArguments, @post, nested: { post: @post, datetime: @datetime }
+
+    assert_rendered_as \
+      "[1, 2, 3], {value_kwarg: #{@post.to_gid}}",
+      JobWithKeywordArgument, [ 1, 2, 3 ], value_kwarg: @post
+
+    assert_rendered_as \
+      "ApplicationJob, {value_kwarg: {nested: gid://dummy/Post/1}}",
+      JobWithKeywordArgument, ApplicationJob, value_kwarg: { nested: @post }
+
+    assert_rendered_as \
+      "hola, {options: {post: gid://dummy/Post/1}, array: [1, 2, 3]}",
+      JobWithMultipleTypeArguments, "hola", options: { post: @post }, array: [ 1, 2, 3 ]
+
+    assert_rendered_as \
+      "ApplicationJob, {}, {datetime: 2024-10-08 12:30:00 UTC}",
+      JobWithMultipleTypeArguments, ApplicationJob, {}, datetime: @datetime
+
+    assert_rendered_as \
+      "[2024-10-08 12:30:00 UTC, gid://dummy/Post/1, ApplicationJob, 1, 2, 3, [1, 2, 3], {nested: here}]",
+      JobWithMultipleTypeArguments, [ @datetime, @post, ApplicationJob, 1, 2, 3, [ 1, 2, 3 ], { nested: :here } ]
+  end
+
+  private
+    def assert_rendered_as(result, job_class, *arguments)
+      job = enqueue_job job_class, *arguments
+      assert_equal result, job_arguments(job)
+    end
+
+    def enqueue_job(klass, *arguments)
+      job = klass.perform_later(*arguments)
+      ActiveJob.jobs.pending.where(queue_name: job.queue_name).find_by_id(job.job_id)
+    end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,6 +60,7 @@ class ActiveSupport::TestCase
     def delete_solid_queue_data
       SolidQueue::Job.find_each(&:destroy)
       SolidQueue::Process.find_each(&:destroy)
+      SolidQueue::RecurringTask.find_each(&:destroy)
     end
 
     def root_resque_redis


### PR DESCRIPTION
Don't deserialize global IDs that are nested inside other arguments (like hashes or arrays), and deserialize these consistently.

Supersedes #125, and fixes #124. 