### PR TITLE
Don't try to enqueue recurring tasks that are undefined

### DIFF
--- a/app/controllers/mission_control/jobs/recurring_tasks_controller.rb
+++ b/app/controllers/mission_control/jobs/recurring_tasks_controller.rb
@@ -1,6 +1,7 @@
 class MissionControl::Jobs::RecurringTasksController < MissionControl::Jobs::ApplicationController
   before_action :ensure_supported_recurring_tasks
   before_action :set_recurring_task, only: [ :show, :update ]
+  before_action :ensure_recurring_task_can_be_enqueued, only: :update
 
   def index
     @recurring_tasks = MissionControl::Jobs::Current.server.recurring_tasks
@@ -14,7 +15,7 @@ class MissionControl::Jobs::RecurringTasksController < MissionControl::Jobs::App
     if (job = @recurring_task.enqueue) && job.successfully_enqueued?
       redirect_to application_job_path(@application, job.job_id), notice: "Enqueued recurring task #{@recurring_task.id}"
     else
-      redirect_to application_recurring_task_path(@application, @recurring_task), alert: "Something went wrong enqueuing this recurring task"
+      redirect_to application_recurring_task_path(@application, @recurring_task.id), alert: "Something went wrong enqueuing this recurring task"
     end
   end
 
@@ -27,5 +28,11 @@ class MissionControl::Jobs::RecurringTasksController < MissionControl::Jobs::App
 
     def set_recurring_task
       @recurring_task = MissionControl::Jobs::Current.server.find_recurring_task(params[:id])
+    end
+
+    def ensure_recurring_task_can_be_enqueued
+      unless @recurring_task.runnable?
+        redirect_to application_recurring_task_path(@application, @recurring_task.id), alert: "This task can't be enqueued"
+      end
     end
 end

--- a/app/models/mission_control/jobs/recurring_task.rb
+++ b/app/models/mission_control/jobs/recurring_task.rb
@@ -16,6 +16,10 @@ class MissionControl::Jobs::RecurringTask
     queue_adapter.enqueue_recurring_task(id)
   end
 
+  def runnable?
+    queue_adapter.can_enqueue_recurring_task?(id)
+  end
+
   private
     attr_reader :queue_adapter
 end

--- a/app/views/mission_control/jobs/recurring_tasks/_actions.html.erb
+++ b/app/views/mission_control/jobs/recurring_tasks/_actions.html.erb
@@ -1,3 +1,5 @@
 <div class="buttons is-right">
-  <%= button_to "Run now", application_recurring_task_path(@application, recurring_task.id), class: "button is-warning is-light mr-0", method: :put %>
+  <% if recurring_task.runnable? %>
+    <%= button_to "Run now", application_recurring_task_path(@application, recurring_task.id), class: "button is-warning is-light mr-0", method: :put %>
+  <% end %>
 </div>

--- a/lib/active_job/queue_adapters/solid_queue_ext/recurring_tasks.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext/recurring_tasks.rb
@@ -26,6 +26,12 @@ module ActiveJob::QueueAdapters::SolidQueueExt::RecurringTasks
     end
   end
 
+  def can_enqueue_recurring_task?(task_id)
+    if task = SolidQueue::RecurringTask.find_by(key: task_id)
+      task.valid?
+    end
+  end
+
   private
     def recurring_task_attributes_from_solid_queue_recurring_task(task)
       {


### PR DESCRIPTION
For example, if running Mission Control from another app than the one where the recurring task classes are defined.

Fixes #200. 

In this case, we hide the button:

<img width="1470" alt="Screenshot 2024-11-10 at 21 27 13" src="https://github.com/user-attachments/assets/7dec7a90-966f-4662-bb21-9695b15ab6a3">

<img width="1480" alt="Screenshot 2024-11-10 at 21 27 18" src="https://github.com/user-attachments/assets/c0f3607f-8eea-40b3-a18b-1f6d97714240">

This could be supported in a future version, changing how Solid Queue works at the moment, perhaps removing support for jobs using another adapter. 