### PR TITLE
Support API-only Rails apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,11 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    propshaft (1.1.0)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
@@ -248,13 +253,6 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (~> 1.3.1)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      sprockets (>= 3.0.0)
     sqlite3 (2.2.0-aarch64-linux-gnu)
     sqlite3 (2.2.0-arm-linux-gnu)
     sqlite3 (2.2.0-arm64-darwin)
@@ -297,6 +295,7 @@ DEPENDENCIES
   debug
   mission_control-jobs!
   mocha
+  propshaft
   puma
   redis
   redis-namespace
@@ -307,7 +306,6 @@ DEPENDENCIES
   rubocop-rails-omakase
   selenium-webdriver
   solid_queue (~> 1.0.1)
-  sprockets-rails
   sqlite3
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ And that's it. With this alone, you should be able to access Mission Control Job
 
 ![Failed jobs tab in a simple app](docs/images/failed-jobs-simple.png)
 
+### API-only apps or apps using `vite_rails`
+
+If you want to use Mission Control – Jobs with an [API-only Rails app](https://guides.rubyonrails.org/api_app.html) or an app that's using `vite_ruby`/`vite_rails`, you need just one more thing: configure an asset pipeline so you can serve the JavaScript and CSS included in this gem. We recommend to use [`propshaft`](https://github.com/rails/propshaft). You simply need to add this line to your application's Gemfile:
+
+```ruby
+gem "propshaft"
+```
+
+Then execute
+```bash
+$ bundle install
+```
+
+And you should be ready to go.
 
 ### Authentication and base controller class
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ And that's it. With this alone, you should be able to access Mission Control Job
 
 ![Failed jobs tab in a simple app](docs/images/failed-jobs-simple.png)
 
-### API-only apps or apps using `vite_rails`
+### API-only apps or apps using `vite_rails` and other asset pipelines outside Rails
 
-If you want to use Mission Control – Jobs with an [API-only Rails app](https://guides.rubyonrails.org/api_app.html) or an app that's using `vite_ruby`/`vite_rails`, you need just one more thing: configure an asset pipeline so you can serve the JavaScript and CSS included in this gem. We recommend to use [`propshaft`](https://github.com/rails/propshaft). You simply need to add this line to your application's Gemfile:
+If you want to use this gem with an [API-only Rails app](https://guides.rubyonrails.org/api_app.html) or an app that's using `vite_ruby`/`vite_rails`, or some other custom asset pipeline different from Sprockets and Propshaft, you need just one more thing: configure an asset pipeline so you can serve the JavaScript and CSS included in this gem. We recommend to use [`Propshaft`](https://github.com/rails/propshaft). You simply need to add this line to your application's Gemfile:
 
 ```ruby
 gem "propshaft"

--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -1,5 +1,13 @@
 class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_controller_class.constantize
+  ActionController::Base::MODULES.each do |mod|
+    include mod unless self < mod
+  end
+
   layout "mission_control/jobs/application"
+
+  # Include helpers if not already included
+  helper MissionControl::Jobs::ApplicationHelper unless self < MissionControl::Jobs::ApplicationHelper
+  helper Importmap::ImportmapTagsHelper unless self < Importmap::ImportmapTagsHelper
 
   include MissionControl::Jobs::ApplicationScoped, MissionControl::Jobs::NotFoundRedirections
   include MissionControl::Jobs::AdapterFeatures

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -82,6 +82,7 @@ module MissionControl
       end
 
       initializer "mission_control-jobs.assets" do |app|
+        app.config.assets.paths << root.join("app/assets/stylesheets")
         app.config.assets.paths << root.join("app/javascript")
         app.config.assets.precompile += %w[ mission_control_jobs_manifest ]
       end

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -7,7 +7,12 @@ module MissionControl
     class Engine < ::Rails::Engine
       isolate_namespace MissionControl::Jobs
 
-      config.middleware.use ActionDispatch::Flash unless config.action_dispatch.flash
+      initializer "mission_control-jobs.middleware" do |app|
+        if app.config.api_only
+          app.middleware.use ActionDispatch::Flash
+          app.middleware.use ::Rack::MethodOverride
+        end
+      end
 
       config.mission_control = ActiveSupport::OrderedOptions.new unless config.try(:mission_control)
       config.mission_control.jobs = ActiveSupport::OrderedOptions.new

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -7,6 +7,8 @@ module MissionControl
     class Engine < ::Rails::Engine
       isolate_namespace MissionControl::Jobs
 
+      config.middleware.use ActionDispatch::Flash unless config.action_dispatch.flash
+
       config.mission_control = ActiveSupport::OrderedOptions.new unless config.try(:mission_control)
       config.mission_control.jobs = ActiveSupport::OrderedOptions.new
 

--- a/mission_control-jobs.gemspec
+++ b/mission_control-jobs.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rails-omakase"
   spec.add_development_dependency "better_html"
-  spec.add_development_dependency "sprockets-rails"
+  spec.add_development_dependency "propshaft"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "puma"
 end

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,3 +1,0 @@
-//= link_tree ../images
-//= link_directory ../stylesheets .css
-//= link mission_control_jobs_manifest.js

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,7 +1,7 @@
 require_relative "boot"
 
 require "rails/all"
-require "sprockets/railtie"
+require "propshaft"
 
 require "resque"
 require "solid_queue"


### PR DESCRIPTION
This is another take on #87, but without the `propshaft` dependency that caused a lot of problems for people using Sprockets. 