### PR TITLE
Adds note to README.md regarding CSS bundling issues on vendored libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ $ bundle install
 
 And you should be ready to go.
 
+*Note: Legacy CSS bundlers `sass-rails` and `sassc-rails` may fail to compile some of the CSS vendored into this library from [Bulma](https://github.com/jgthms/bulma), which was created in [Dart SASS](https://sass-lang.com/dart-sass/). You will therefore need to upgrade to `dartsass-rails` or some library that relies on it, like `cssbundling-rails`.*
+
 ### Authentication and base controller class
 
 By default, Mission Control's controllers will extend the host app's `ApplicationController`. If no authentication is enforced, `/jobs` will be available to everyone. You might want to implement some kind of authentication for this in your app. To make this easier, you can specify a different controller as the base class for Mission Control's controllers:


### PR DESCRIPTION
From version 0.5.0 to 0.6.0, `bulma.min.css` was vendored into the lib instead of linking to the CDN version to better conform to the content security policy.

Unfortunately, when passing through a common older CSS bundler (sass-rails) during `rails assets:precompile`, that CSS doesn't seem to pass muster:
```
SassC::SyntaxError: Error: Invalid CSS after "...--s),var(--l));": expected "}", was "--00-l:var(--bulma-" (SassC::SyntaxError)
```

I assume Bulma is using some feature of DartSass/CSS that `sass-rails` and `sassc-rails` do not support. Updating the CSS bundler to `dartsass-rails` fixes the issue.