### PR TITLE
Set `default_locale` for custom I18n config

### DIFF
--- a/lib/mission_control/jobs/i18n_config.rb
+++ b/lib/mission_control/jobs/i18n_config.rb
@@ -2,4 +2,8 @@ class MissionControl::Jobs::I18nConfig < ::I18n::Config
   def available_locales
     [ :en ]
   end
+
+  def default_locale
+    :en
+  end
 end


### PR DESCRIPTION
Otherwise, the `with_locale` block will try to set back any locale set by the host app, which might or might not be `:en`, leading to an `I18n::InvalidLocale` error.

Addresses #219.