### PR TITLE
Display job reexecutions and job id

### DIFF
--- a/app/views/mission_control/jobs/jobs/_general_information.html.erb
+++ b/app/views/mission_control/jobs/jobs/_general_information.html.erb
@@ -26,6 +26,12 @@
       <%= time_distance_in_words_with_title(job.enqueued_at.to_datetime) %> ago
     </td>
   </tr>
+  <% if job.executions > 0 %>
+    <tr>
+      <th>Retries</th>
+      <td><%= job.executions %></td>
+    </tr>
+  <% end %>
   <% if job.scheduled? %>
     <tr>
       <th>Scheduled</th>

--- a/app/views/mission_control/jobs/jobs/scheduled/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/scheduled/_job.html.erb
@@ -1,6 +1,9 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td>
   <%= bidirectional_time_distance_in_words_with_title(job.scheduled_at) %>
+  <% if job.executions > 0 %>
+    <div class="is-warning tag ml-4"><%= job.executions.ordinalize %> retry</div>
+  <% end %>
   <% if job_delayed?(job) %>
     <div class="is-danger tag ml-4">delayed</div>
   <% end %>

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -41,6 +41,18 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", /AutoRetryingJob\s+failed\s+/
     assert_includes response.body, job.job_id
     assert_select "div.is-danger", "failed"
+    assert_select "tr", /Retries\s+2/
+  end
+
+  test "get scheduled jobs flagging retries" do
+    DummyJob.set(wait: 1.hour).perform_later(42)
+    DummyJob.new(43).tap { |job| job.executions = 1 }.enqueue(wait: 1.hour)
+
+    get mission_control_jobs.application_jobs_url(@application, :scheduled)
+    assert_response :ok
+
+    assert_select "tr.job", 2
+    assert_select "tr.job div.tag", text: "1st retry", count: 1
   end
 
   test "get blocked jobs with their expiration" do


### PR DESCRIPTION
## Background / problem

There are some things that are hard to distinguish at first glance regarding job instances, executions and reexecutions. I think a factor is that I am not used to the terminology / internals, since I mostly used sidekiq.

<details><summary>An example:</summary>
<img width="1004" alt="Screenshot 2024-12-07 at 11 55 19" src="https://github.com/user-attachments/assets/41bc564f-cd1a-40bd-90de-7e7e7a5c09d0">
</details>

Here you can't see to what instance these jobs belong. Three may be related to `a759850e-3b87-44be-ba63-3d98ab92771b` and one to `c24aa402-b669-437c-80ea-e3b603e87dc2`. Knowing the instance can help understand that the same job (instance) has been reexecuted multiple times because there was an exception.

Sometimes when you click one of these "finished jobs", you'll land in a job with the `finished` label, while in others you'll go to a scheduled job (because it's still being reexecuted due to an exception). It's also a bit surprising to me that these are called "jobs", but we see multiple rows for the same job instance.

Then in scheduled jobs, you can't see if a job is part of a reexecution or not

## Changes

Added the first part of the job id to the list. This helps understanding a bit reexecutions
<details><summary>Change:</summary>
<img width="882" alt="Screenshot 2024-12-07 at 12 21 18" src="https://github.com/user-attachments/assets/ea0a6556-a32c-479a-a60c-e50c262ad562">
</details>

Added a reexecution label in the jobs in finished/scheduled:
<details><summary>Change:</summary>
<img width="553" alt="Screenshot 2024-12-07 at 12 25 40" src="https://github.com/user-attachments/assets/f1ea51b9-c9b5-4b9e-82e4-5e0f8752c11a">
<img width="605" alt="Screenshot 2024-12-07 at 12 25 46" src="https://github.com/user-attachments/assets/b7ee737c-98b1-48f0-8437-9cb431c2fc71">
</details>


and in the scheduled view:
<details><summary>Change:</summary>
<img width="1381" alt="Screenshot 2024-12-07 at 12 27 06" src="https://github.com/user-attachments/assets/3e585e3d-cd93-412d-b938-7cacc69fe577">
</details>

## Questions/Asks

 I'm not sure if it fits the terminology, but wouldn't `Finished job executions` fit better than `Finished jobs`? There are multiple rows for the same job instance.

I don't mind changes to this PR, so if it can serve as a starting point, feel free to modify it (styles or anything)  or create a new one 🙏.

I think it'd be nice to show as well in the `Finished jobs` list if a job is 'done done' or if it's still being reexecuted / failed / blocked. But with just the information `job` has, I didn't see a way.

