### PR TITLE
Define `available_locales_set` to not pollute the global one

### DIFF
--- a/lib/mission_control/jobs/i18n_config.rb
+++ b/lib/mission_control/jobs/i18n_config.rb
@@ -1,9 +1,17 @@
 class MissionControl::Jobs::I18nConfig < ::I18n::Config
+  AVAILABLE_LOCALES = [ :en ]
+  AVAILABLE_LOCALES_SET = [ :en, "en" ]
+  DEFAULT_LOCALE = :en
+
   def available_locales
-    [ :en ]
+    AVAILABLE_LOCALES
+  end
+
+  def available_locales_set
+    AVAILABLE_LOCALES_SET
   end
 
   def default_locale
-    :en
+    DEFAULT_LOCALE
   end
 end


### PR DESCRIPTION
In multi-threaded servers when Mission Control is requested before other pages in the host app.

Fixes #229