### PR TITLE
fix routing when main app has included url_helpers

### DIFF
--- a/app/helpers/mission_control/jobs/application_helper.rb
+++ b/app/helpers/mission_control/jobs/application_helper.rb
@@ -4,5 +4,6 @@ module MissionControl::Jobs
     #
     # We can't rely on +config.action_controller.include_all_helpers = true+ in the host app.
     include DatesHelper, JobsHelper, NavigationHelper, InterfaceHelper
+    include MissionControl::Jobs::Engine.routes.url_helpers
   end
 end


### PR DESCRIPTION
I made a similiar fix to audits1984 even though I do not fully comprehend the issue :) 
(https://github.com/basecamp/audits1984/pull/54)

The main issue is that the routing breaks if the host app has included Rails.application.routes.url_helpers

