### PR TITLE
Fix: Extra Options in Dropdown for Job Class and Queue Name Filters

### DIFF
--- a/app/views/mission_control/jobs/jobs/_filters.html.erb
+++ b/app/views/mission_control/jobs/jobs/_filters.html.erb
@@ -5,11 +5,11 @@
         data: { controller: "form", action: "input->form#debouncedSubmit" } do |form| %>
 
         <div class="select is-rounded">
-          <%= form.text_field :job_class_name, value: @job_filters[:job_class_name], class: "input", list: "job-classes", placeholder: "Filter by job class..." %>
+          <%= form.text_field :job_class_name, value: @job_filters[:job_class_name], class: "input", list: "job-classes", placeholder: "Filter by job class...", autocomplete: "off" %>
         </div>
 
         <div class="select is-rounded">
-          <%= form.text_field :queue_name, value: @job_filters[:queue_name], class: "input", list: "queue-names", placeholder: "Filter by queue name..." %>
+          <%= form.text_field :queue_name, value: @job_filters[:queue_name], class: "input", list: "queue-names", placeholder: "Filter by queue name...", autocomplete: "off" %>
         </div>
 
         <% if jobs_status == "finished" %>


### PR DESCRIPTION
The `autocomplete` attribute has been set to `off` for the respective search fields to resolve this issue. This ensures that only valid entries (e.g., `job_classes` and `queue_names`) are displayed in the dropdown, preventing irrelevant user-inputted values from appearing.

**Fixes**: #239   

**Changes**:  
- Disabled `autocomplete` for "Filter by Job Class" and "Filter by Queue Name" fields.

**Screenshots**:  
Before:  
![Screenshot from 2025-01-23 22-35-48](https://github.com/user-attachments/assets/527144ec-6d60-4a53-9c6f-e0d2f9361290)
After:  
![Screenshot from 2025-01-24 08-51-43](https://github.com/user-attachments/assets/be412cd0-ddc2-4831-9191-57a1468056be)