### PR TITLE
Stop checking for file updates in production

### DIFF
--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -103,10 +103,12 @@ module MissionControl
 
       initializer "mission_control-jobs.importmap", after: "importmap" do |app|
         MissionControl::Jobs.importmap.draw(root.join("config/importmap.rb"))
-        MissionControl::Jobs.importmap.cache_sweeper(watches: root.join("app/javascript"))
+        if app.config.importmap.sweep_cache && app.config.reloading_enabled?
+          MissionControl::Jobs.importmap.cache_sweeper(watches: root.join("app/javascript"))
 
-        ActiveSupport.on_load(:action_controller_base) do
-          before_action { MissionControl::Jobs.importmap.cache_sweeper.execute_if_updated }
+          ActiveSupport.on_load(:action_controller_base) do
+            before_action { MissionControl::Jobs.importmap.cache_sweeper.execute_if_updated }
+          end
         end
       end
     end


### PR DESCRIPTION
While upgrading the lobsters benchmark in yjit-bench I noticed 2.8% of the overall time spent in `Dir[]`, all coming from FileUpdateChecker, which shouldn't be a thing in production.

After tracking it down, it comes from mission-control.

Profile: https://share.firefox.dev/4hBdygq
Ref: https://github.com/Shopify/yjit-bench/pull/358

NB: I'm really unfamiliar with the gem, so don't assume this PR is correct.