### PR TITLE
readme: ommit double quotes from `connect_to` usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Available job servers:
 
 And then:
 ```
->> connect_to "hey:solid_queue"
+>> connect_to hey:solid_queue
 Connected to hey:solid_queue
 ```
 


### PR DESCRIPTION
I don't know why, but when using double quotes, it throws `MissionControl::Jobs::Errors::ResourceNotFound`. I have checked the source code and done some debugging, but I couldn't find the solution. I'm fairly certain the culprit is in these lines.

https://github.com/rails/mission_control-jobs/blob/58893d968189b494170f558ade76514804eb33ca/lib/mission_control/jobs/console/connect_to.rb#L8-L10

https://github.com/rails/mission_control-jobs/blob/58893d968189b494170f558ade76514804eb33ca/lib/mission_control/jobs/server/serializable.rb#L11-L13
- This PR also answer #230 