### PR TITLE
Truncate job arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test/dummy/tmp/
 .DS_Store
 .ruby-gemset
+.idea

--- a/app/controllers/mission_control/jobs/many_discards_controller.rb
+++ b/app/controllers/mission_control/jobs/many_discards_controller.rb
@@ -1,0 +1,15 @@
+class MissionControl::Jobs::ManyDiscardsController < MissionControl::Jobs::ApplicationController
+  def create
+    discarded_jobs = job_ids.map do |job_id|
+      job = ActiveJob.jobs.find_by_id(job_id)
+      job.discard if job&.failed?
+    end.compact
+    redirect_to request.referer, notice: "Discarded #{discarded_jobs.size} of #{job_ids.size} selected jobs"
+  end
+
+  private
+
+  def job_ids
+    params[:job_ids].reject(&:blank?)
+  end
+end

--- a/app/controllers/mission_control/jobs/many_retries_controller.rb
+++ b/app/controllers/mission_control/jobs/many_retries_controller.rb
@@ -1,0 +1,15 @@
+class MissionControl::Jobs::ManyRetriesController < MissionControl::Jobs::ApplicationController
+  def create
+    retried_jobs = job_ids.map do |job_id|
+      job = ActiveJob.jobs.find_by_id(job_id)
+      job.retry if job&.failed?
+    end.compact
+    redirect_to request.referer, notice: "Retried #{retried_jobs.size} of #{job_ids.size} selected jobs"
+  end
+
+  private
+
+  def job_ids
+    params[:job_ids].reject(&:blank?)
+  end
+end

--- a/app/helpers/mission_control/jobs/jobs_helper.rb
+++ b/app/helpers/mission_control/jobs/jobs_helper.rb
@@ -1,10 +1,12 @@
 module MissionControl::Jobs::JobsHelper
+  MAX_ARGUMENTS_LENGTH = 500
+
   def job_title(job)
     job.job_class_name
   end
 
   def job_arguments(job)
-    renderable_job_arguments_for(job).join(", ")
+    serialized_arguments = renderable_job_arguments_for(job).join(", ").truncate(MAX_ARGUMENTS_LENGTH)
   end
 
   def failed_job_error(job)

--- a/app/javascript/mission_control/jobs/controllers/jobs_controller.js
+++ b/app/javascript/mission_control/jobs/controllers/jobs_controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ['discardSelectedButton', 'retrySelectedButton', 'discardAllButton', 'retryAllButton', 'checkbox']
+
+  initialize() {
+    this.selectedJobs = []
+  }
+
+  toggleJob(event) {
+    let checkbox = null
+    if (event.target.tagName === 'INPUT') {
+      checkbox = event.target
+    } else {
+      checkbox = this.checkboxTargets.find(checkboxTarget => checkboxTarget.value === event.currentTarget.dataset.jobId)
+      checkbox.checked = !checkbox.checked
+    }
+
+    if (checkbox.checked) {
+      this.selectedJobs.push(checkbox.value)
+    } else {
+      const index = this.selectedJobs.indexOf(checkbox.value)
+      this.selectedJobs.splice(index, 1)
+    }
+
+    this.updateButtons()
+  }
+
+  updateButtons() {
+    if (this.selectedJobs.length > 0) {
+      this.discardSelectedButtonTarget.classList.remove('is-hidden')
+      this.retrySelectedButtonTarget.classList.remove('is-hidden')
+      this.discardAllButtonTarget.classList.add('is-hidden')
+      this.retryAllButtonTarget.classList.add('is-hidden')
+    } else {
+      this.discardSelectedButtonTarget.classList.add('is-hidden')
+      this.retrySelectedButtonTarget.classList.add('is-hidden')
+      this.discardAllButtonTarget.classList.remove('is-hidden')
+      this.retryAllButtonTarget.classList.remove('is-hidden')
+    }
+  }
+
+}

--- a/app/views/mission_control/jobs/jobs/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/_job.html.erb
@@ -1,13 +1,31 @@
-<tr class="job">
-  <td>
-    <%= link_to job_title(job), application_job_path(@application, job.job_id) %>
+<% if jobs_status.failed? %>
+  <tr class="job" data-action="click->jobs#toggleJob" data-job-id="<%= job.job_id %>">
+    <td>
+      <%= check_box_tag 'job_ids[]', job.job_id, false, form: 'many_job_operations', class: 'job-checkbox',
+        data: { "jobs-target" => "checkbox" } %>
+      <%= link_to job_title(job), application_job_path(@application, job.job_id) %>
 
-    <% if job.serialized_arguments.present? %>
-      <div class="is-family-monospace"><%= job_arguments(job) %></div>
-    <% end %>
+      <% if job.serialized_arguments.present? %>
+        <div class="is-family-monospace"><%= job_arguments(job) %></div>
+      <% end %>
 
-    <div class="has-text-grey is-size-7">Enqueued <%= time_distance_in_words_with_title(job.enqueued_at.to_datetime) %> ago</div>
-  </td>
+      <div class="has-text-grey is-size-7">Enqueued <%= time_distance_in_words_with_title(job.enqueued_at.to_datetime) %> ago</div>
+    </td>
 
-  <%= render "mission_control/jobs/jobs/#{jobs_status}/job", job: job %>
-</tr>
+    <%= render "mission_control/jobs/jobs/#{jobs_status}/job", job: job %>
+  </tr>
+<% else %>
+  <tr class="job">
+    <td>
+      <%= link_to job_title(job), application_job_path(@application, job.job_id) %>
+
+      <% if job.serialized_arguments.present? %>
+        <div class="is-family-monospace"><%= job_arguments(job) %></div>
+      <% end %>
+
+      <div class="has-text-grey is-size-7">Enqueued <%= time_distance_in_words_with_title(job.enqueued_at.to_datetime) %> ago</div>
+    </td>
+
+    <%= render "mission_control/jobs/jobs/#{jobs_status}/job", job: job %>
+  </tr>
+<% end %>

--- a/app/views/mission_control/jobs/jobs/_toolbar.html.erb
+++ b/app/views/mission_control/jobs/jobs/_toolbar.html.erb
@@ -6,13 +6,23 @@
   <% end %>
 
   <% if jobs_status.failed? %>
-    <% target = active_filters? ? "selection" : "all" %>
+    <% target = active_filters? ? "filtered" : "all" %>
 
-    <%= button_to "Discard #{target}", application_bulk_discards_path(@application, **jobs_filter_param),
-      method: :post, disabled: jobs_count == 0, class: "button is-danger is-light",
-      form: { data: { turbo_confirm: "This will delete #{jobs_count} jobs and can't be undone. Are you sure?" } } %>
-    <%= button_to "Retry #{target}", application_bulk_retries_path(@application, **jobs_filter_param),
-      method: :post, disabled: jobs_count == 0,
-      class: "button is-warning is-light mr-0" %>
+
+    <%= form_with url: '#', method: :post, id: 'many_job_operations' do |f| %>
+      <%= f.button "Discard selected", formaction: application_many_discards_path(@application),
+        class: "button is-danger is-light is-hidden", data: { "jobs-target": "discardSelectedButton" } %>
+      <%= f.button "Retry selected", formaction: application_many_retries_path(@application),
+        class: "button is-warning is-light is-hidden", data: { "jobs-target": "retrySelectedButton" } %>
+      <%= f.button "Discard #{target}", formaction: application_bulk_discards_path(@application, **jobs_filter_param),
+        class: "button is-danger is-light", disabled: jobs_count == 0,
+        data: { turbo_confirm: "This will delete #{jobs_count} jobs and can't be undone. Are you sure?",
+          "jobs-target": "discardAllButton" } %>
+      <%= f.button "Retry #{target}", formaction: application_bulk_retries_path(@application, **jobs_filter_param),
+        class: "button is-warning is-light mr-0", disabled: jobs_count == 0,
+        data: { turbo_confirm: "This will retry #{jobs_count} jobs. Are you sure?",
+          "jobs-target": "retryAllButton" } %>
+    <% end %>
+
   <% end %>
 </div>

--- a/app/views/mission_control/jobs/jobs/index.html.erb
+++ b/app/views/mission_control/jobs/jobs/index.html.erb
@@ -3,17 +3,19 @@
 <% if @jobs_page.empty? && !active_filters? %>
   <%= blank_status_notice "There are no #{jobs_status.dasherize} jobs #{blank_status_emoji(jobs_status)}" %>
 <% else %>
-  <div class="level is-flex-wrap-wrap">
-    <%= render "mission_control/jobs/jobs/filters", job_class_names: @job_class_names, queue_names: @queue_names %>
-    <%= render "mission_control/jobs/jobs/toolbar", jobs_count: @jobs_count %>
+  <div data-controller="jobs">
+    <div class="level is-flex-wrap-wrap">
+      <%= render "mission_control/jobs/jobs/filters", job_class_names: @job_class_names, queue_names: @queue_names %>
+      <%= render "mission_control/jobs/jobs/toolbar", jobs_count: @jobs_count %>
+    </div>
+
+    <% if @jobs_page.empty? %>
+      <%= blank_status_notice "No #{jobs_status.dasherize} jobs found with the given filters" %>
+    <% else %>
+      <%= render "mission_control/jobs/jobs/jobs_page", jobs_page: @jobs_page %>
+
+      <%= render "mission_control/jobs/shared/pagination_toolbar", page: @jobs_page, filter_param: jobs_filter_param %>
+    <% end %>
   </div>
-
-  <% if @jobs_page.empty? %>
-    <%= blank_status_notice "No #{jobs_status.dasherize} jobs found with the given filters" %>
-  <% else %>
-    <%= render "mission_control/jobs/jobs/jobs_page", jobs_page: @jobs_page %>
-
-    <%= render "mission_control/jobs/shared/pagination_toolbar", page: @jobs_page, filter_param: jobs_filter_param %>
-  <% end %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ MissionControl::Jobs::Engine.routes.draw do
       collection do
         resource :bulk_retries, only: :create
         resource :bulk_discards, only: :create
+        resource :many_retries, only: :create
+        resource :many_discards, only: :create
       end
     end
 

--- a/test/controllers/many_discards_controller_test.rb
+++ b/test/controllers/many_discards_controller_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class MissionControl::Jobs::ManyDiscardsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    FailingJob.queue_as :queue_1
+    @failed_job1 = FailingJob.perform_later(42)
+    @failed_job2 = FailingJob.perform_later(43)
+    @failed_job3 = FailingJob.perform_later(44)
+    perform_enqueued_jobs_async
+    @referer = mission_control_jobs.application_jobs_url(@application, :failed)
+  end
+
+  test "discards multiple selected failed jobs" do
+    assert_difference -> { ActiveJob.jobs.failed.count }, -2 do
+      post mission_control_jobs.application_many_discards_url(@application), params: {
+        job_ids: [ @failed_job1.job_id, @failed_job2.job_id ]
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Discarded 2 of 2 selected jobs", flash[:notice]
+    assert_equal 1, ActiveJob.jobs.failed.count
+    assert_equal [ @failed_job3.job_id ], ActiveJob.jobs.failed.map(&:job_id)
+  end
+
+  test "handles mix of failed and non-failed jobs" do
+    @failed_job2.retry
+    perform_enqueued_jobs_async
+
+    assert_difference -> { ActiveJob.jobs.failed.count }, -1 do
+      post mission_control_jobs.application_many_discards_url(@application), params: {
+        job_ids: [ @failed_job1.job_id, @failed_job2.job_id ]
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Discarded 1 of 2 selected jobs", flash[:notice]
+    assert_equal 1, ActiveJob.jobs.failed.count
+    assert_equal [ @failed_job3.job_id ], ActiveJob.jobs.failed.map(&:job_id)
+  end
+
+  test "handles non-existent job IDs gracefully" do
+    assert_difference -> { ActiveJob.jobs.failed.count }, -1 do
+      post mission_control_jobs.application_many_discards_url(@application), params: {
+        job_ids: [ nil, "non_existent_id", @failed_job1.job_id ]
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Discarded 1 of 2 selected jobs", flash[:notice]
+    assert_equal 2, ActiveJob.jobs.failed.count
+    assert_equal [ @failed_job2.job_id, @failed_job3.job_id ].sort, ActiveJob.jobs.failed.map(&:job_id).sort
+  end
+
+  test "handles empty job IDs array" do
+    assert_no_difference -> { ActiveJob.jobs.failed.count } do
+      post mission_control_jobs.application_many_discards_url(@application), params: {
+        job_ids: []
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Discarded 0 of 0 selected jobs", flash[:notice]
+    assert_equal 3, ActiveJob.jobs.failed.count
+    assert_equal [ @failed_job1.job_id, @failed_job2.job_id, @failed_job3.job_id ].sort, ActiveJob.jobs.failed.map(&:job_id).sort
+  end
+end

--- a/test/controllers/many_retries_controller_test.rb
+++ b/test/controllers/many_retries_controller_test.rb
@@ -1,0 +1,67 @@
+# require_relative "../application_system_test_case.rb"
+require "test_helper"
+
+class MissionControl::Jobs::ManyRetriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    FailingJob.queue_as :queue_1
+    @failed_job1 = FailingJob.perform_later(42)
+    @failed_job2 = FailingJob.perform_later(43)
+    @failed_job3 = FailingJob.perform_later(44)
+    perform_enqueued_jobs_async
+    @referer = mission_control_jobs.application_jobs_url(@application, :failed)
+  end
+
+  test "retries multiple selected failed jobs" do
+    assert_difference -> { ActiveJob.jobs.failed.count }, -2 do
+      post mission_control_jobs.application_many_retries_url(@application), params: {
+        job_ids: [ @failed_job1.job_id, @failed_job2.job_id ]
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Retried 2 of 2 selected jobs", flash[:notice]
+    assert_equal 2, ActiveJob.jobs.pending.count
+    assert_equal [ @failed_job1.job_id, @failed_job2.job_id ].sort, ActiveJob.jobs.pending.map(&:job_id).sort
+  end
+
+  test "handles mix of failed and non-failed jobs" do
+    @failed_job2.retry
+    perform_enqueued_jobs_async
+
+    assert_difference -> { ActiveJob.jobs.failed.count }, -2 do
+      post mission_control_jobs.application_many_retries_url(@application), params: {
+        job_ids: [ @failed_job1.job_id, @failed_job2.job_id, @failed_job3.job_id ]
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Retried 2 of 3 selected jobs", flash[:notice]
+    assert_equal 3, ActiveJob.jobs.pending.count
+    assert_equal [ @failed_job1.job_id, @failed_job2.job_id, @failed_job3.job_id ].sort, ActiveJob.jobs.pending.map(&:job_id).sort
+  end
+
+  test "handles non-existent job IDs gracefully" do
+    assert_difference -> { ActiveJob.jobs.failed.count }, -1 do
+      post mission_control_jobs.application_many_retries_url(@application), params: {
+        job_ids: [ nil, "non_existent_id", @failed_job1.job_id ]
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Retried 1 of 2 selected jobs", flash[:notice]
+    assert_equal 1, ActiveJob.jobs.pending.count
+    assert_equal [ @failed_job1.job_id ].sort, ActiveJob.jobs.pending.map(&:job_id).sort
+  end
+
+  test "handles empty job IDs array" do
+    assert_no_difference -> { ActiveJob.jobs.failed.count } do
+      post mission_control_jobs.application_many_retries_url(@application), params: {
+        job_ids: []
+      }, headers: { "HTTP_REFERER": @referer }
+    end
+
+    assert_redirected_to @referer
+    assert_equal "Retried 0 of 0 selected jobs", flash[:notice]
+    assert_equal 0, ActiveJob.jobs.pending.count
+  end
+end

--- a/test/system/retry_jobs_test.rb
+++ b/test/system/retry_jobs_test.rb
@@ -14,7 +14,9 @@ class RetryJobsTest < ApplicationSystemTestCase
   test "retry all failed jobs" do
     assert_equal 9, job_row_elements.length
 
-    click_on "Retry all"
+    accept_confirm do
+      click_on "Retry all"
+    end
 
     assert_text "Retried 9 jobs"
     assert_empty job_row_elements
@@ -39,7 +41,10 @@ class RetryJobsTest < ApplicationSystemTestCase
     fill_in "filter[job_class_name]", with: "FailingJob"
     assert_text /6 jobs found/i
 
-    click_on "Retry selection"
+    accept_confirm do
+      click_on "Retry filtered"
+    end
+
     assert_text /retried 6 jobs/i
     assert_equal 3, job_row_elements.length
   end
@@ -50,7 +55,10 @@ class RetryJobsTest < ApplicationSystemTestCase
     fill_in "filter[queue_name]", with: "queue_1"
     assert_text /4 jobs found/i
 
-    click_on "Retry selection"
+    accept_confirm do
+      click_on "Retry filtered"
+    end
+
     assert_text /retried 4 jobs/i
     assert_equal 5, job_row_elements.length
   end


### PR DESCRIPTION
### How to test

- Enqueue a job with a long input argument with `DummyJob.perform_later(sleep_time: "a"*600)`
- Point to this branch by updating `Gemfie` with `gem "mission_control-jobs", git: "https://github.com/fullscript/mission_control-jobs.git", branch: "truncate-job-arguments"`
- Navigate to http://localhost:3000/a/jobs/applications/hwadmin/queues/within_1_minute?server_id=solid_queue
- Ensure that the input arguments are truncated.