### PR TITLE
Add filtering to failed jobs

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/job_filters.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_filters.rb
@@ -12,6 +12,7 @@ module MissionControl::Jobs::JobFilters
       @job_filters = {
         job_class_name: params.dig(:filter, :job_class_name).presence,
         queue_name: params.dig(:filter, :queue_name).presence,
+        error: params.dig(:filter, :error).presence,
         finished_at: finished_at_range_params
       }.compact
     end

--- a/app/views/mission_control/jobs/jobs/_filters.html.erb
+++ b/app/views/mission_control/jobs/jobs/_filters.html.erb
@@ -12,6 +12,10 @@
           <%= form.text_field :queue_name, value: @job_filters[:queue_name], class: "input", list: "queue-names", placeholder: "Filter by queue name...", autocomplete: "off" %>
         </div>
 
+        <div class="text is-rounded">
+          <%= form.text_field :error, value: @job_filters[:error], class: "input", placeholder: "Search by error...", autocomplete: "off" %>
+        </div>
+
         <% if jobs_status == "finished" %>
           <div class="select is-rounded">
             <%= form.datetime_field :finished_at_start, value: @job_filters[:finished_at]&.begin, class: "input", placeholder: "Finished from" %>

--- a/lib/active_job/job_proxy.rb
+++ b/lib/active_job/job_proxy.rb
@@ -20,6 +20,10 @@ class ActiveJob::JobProxy < ActiveJob::Base
     end
   end
 
+  def error
+    @last_execution_error.to_s
+  end
+
   def perform_now
     raise UnsupportedError, "A JobProxy doesn't support immediate execution, only enqueuing."
   end

--- a/test/active_job/jobs_relation_test.rb
+++ b/test/active_job/jobs_relation_test.rb
@@ -38,6 +38,11 @@ class ActiveJob::JobsRelationTest < ActiveSupport::TestCase
     assert_equal "MyJob", jobs.job_class_name
   end
 
+  test "set error" do
+    jobs = @jobs.where(error: "Some error")
+    assert_equal "Some error", jobs.error
+  end
+
   test "set finished_at range" do
     jobs = @jobs.where(finished_at: (1.day.ago..))
     assert 1.hour.ago.in? jobs.finished_at

--- a/test/dummy/app/jobs/failing_job.rb
+++ b/test/dummy/app/jobs/failing_job.rb
@@ -1,5 +1,5 @@
 class FailingJob < ApplicationJob
-  def perform(value = nil)
-    raise "This always fails!"
+  def perform(value = "This always fails!", error = RuntimeError)
+    raise error, value
   end
 end

--- a/test/system/list_failed_jobs_test.rb
+++ b/test/system/list_failed_jobs_test.rb
@@ -17,4 +17,19 @@ class ListFailedJobsTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test "filter by error message" do
+    2.times { |index| FailingJob.perform_later("Ratelimit Error") }
+    perform_enqueued_jobs
+
+    visit jobs_path(:failed, filter: { error: "Ratelimit" })
+
+    assert_equal 2, job_row_elements.length
+    job_row_elements.each.with_index do |job_element, index|
+      within job_element do
+        assert_text "FailingJob"
+        assert_text "Ratelimit Error" # Ensure the error message is displayed"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds filtering to failed jobs.  This is a common use case where you might want to retry or discard only a subset of jobs.  

Note that this isn't super performant, I think `jobs_relation` loads everything and so this can be jumpy at times.  I'm open to other solutions but seemed much larger than this PR. 

Demo:


https://github.com/user-attachments/assets/f9eda8c9-4339-4188-bb4f-075528c1e08c

