### PR TITLE
Add link to main app root path in the navbar

### DIFF
--- a/app/views/layouts/mission_control/jobs/_application_selection.html.erb
+++ b/app/views/layouts/mission_control/jobs/_application_selection.html.erb
@@ -1,6 +1,9 @@
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-menu is-active mb-4">
     <div class="navbar-start">
+      <% if defined?(main_app.root_path) %>
+        <%= link_to "Back to main app", main_app.root_path %>
+      <% end %>
     </div>
 
     <div class="navbar-end">


### PR DESCRIPTION
Closes #155 

Adds a link to the `application_selection` navbar that redirects to the `main_app.root_path`: 

![CleanShot 2025-05-07 at 16 55 24@2x](https://github.com/user-attachments/assets/34e6bd2d-e0ea-4aa6-864c-d752ef296187)

Note that the `main_app.root_path` may not be defined, as there are no rules in Rails that enforce an app to have a root path; hence the extra precaution in the code with the check `defined?(main_app.root_path)`. 

As a result some users may not understand why the link does not show up in their app, but as suggested in the issue discussion](https://github.com/rails/mission_control-jobs/issues/155#issuecomment-2464811540), this could be resolved by a configuration option as an iteration of this later on. 

I am open on adding it here though, as it shouldn't be too much additional work. 