### PR TITLE
Change default job ordering to newest first

### DIFF
--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -204,7 +204,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
             # Follow polling order for scheduled executions, the rest by job_id, desc or asc
           when solid_queue_status.scheduled? then executions.ordered
           when recurring_task_id.present?    then executions.order(job_id: :desc)
-          else executions.order(job_id: :asc)
+          else executions.order(job_id: :desc)
           end
         end
 


### PR DESCRIPTION
close #246 

## Summary
This pull request updates the default sorting behavior of job executions to display the most recent jobs first (job_id: :desc) instead of the oldest first (job_id: :asc).

- As discussed in [#246](https://github.com/rails/mission_control-jobs/issues/246), the current ordering (oldest-first) can be confusing, especially when inspecting failed or completed jobs.
- Showing the latest jobs at the top improves usability by surfacing the most relevant entries without needing to paginate or scroll.

## Memo
Rather than introducing full sorting functionality (which would require larger UI and backend changes), this PR focuses only on reversing the default sort order.

In most cases, sorting jobs in ascending order provides little benefit. On the other hand, defaulting to newest-first is more intuitive and practical — especially for failed or completed jobs. Therefore, this change applies the new default more broadly.
