### PR TITLE
Display job duration for finished ones

### DIFF
--- a/app/views/mission_control/jobs/jobs/_general_information.html.erb
+++ b/app/views/mission_control/jobs/jobs/_general_information.html.erb
@@ -47,9 +47,15 @@
   <% end %>
   <% if job.finished_at.present? %>
     <tr>
-      <th>Finished at</th>
+      <th>Finished</th>
       <td>
         <%= time_distance_in_words_with_title(job.finished_at) %> ago
+      </td>
+    </tr>
+    <tr>
+      <th>Duration</th>
+      <td>
+        <%= job.duration.round(3) %> seconds
       </td>
     </tr>
   <% end %>

--- a/lib/active_job/job_proxy.rb
+++ b/lib/active_job/job_proxy.rb
@@ -24,6 +24,10 @@ class ActiveJob::JobProxy < ActiveJob::Base
     raise UnsupportedError, "A JobProxy doesn't support immediate execution, only enqueuing."
   end
 
+  def duration
+    finished_at - scheduled_at
+  end
+
   ActiveJob::JobsRelation::STATUSES.each do |status|
     define_method "#{status}?" do
       self.status == status


### PR DESCRIPTION
To help discover which jobs are fast/slow.

I tried to add a simple test:

```ruby
module ActiveJob::QueueAdapters::AdapterTesting::JobDetails
  extend ActiveSupport::Testing::Declarative

  test "returns job duration" do
    DummyJob.perform_later
    perform_enqueued_jobs

    job = ActiveJob.jobs.last

    assert_job_proxy DummyJob, job
    assert job.job_id
  end
end
```

but this fails for both adapters with:
```
Error:
ActiveJob::QueueAdapters::ResqueTest#test_returns_job_duration:
NoMethodError: undefined method 'serialized_arguments' for nil
    test/active_job/queue_adapters/adapter_testing/job_details.rb:11:in 'block in <module:JobDetails>'
```

```
Error:
ActiveJob::QueueAdapters::SolidQueueTest#test_returns_job_duration:
ActiveJob::Errors::QueryError: Status not supported: 
    lib/active_job/queue_adapters/solid_queue_ext.rb:231:in 'ActiveJob::QueueAdapters::SolidQueueExt::SolidQueueJobs#execution_class_by_status'
    lib/active_job/queue_adapters/solid_queue_ext.rb:179:in 'ActiveJob::QueueAdapters::SolidQueueExt::SolidQueueJobs#executions'
    lib/active_job/queue_adapters/solid_queue_ext.rb:151:in 'ActiveJob::QueueAdapters::SolidQueueExt::SolidQueueJobs#jobs'
    lib/active_job/queue_adapters/solid_queue_ext.rb:51:in 'ActiveJob::QueueAdapters::SolidQueueExt#fetch_jobs'
    lib/active_job/jobs_relation.rb:256:in 'ActiveJob::JobsRelation#perform_each'
    lib/active_job/jobs_relation.rb:243:in 'ActiveJob::JobsRelation#load_jobs'
    lib/active_job/jobs_relation.rb:125:in 'ActiveJob::JobsRelation#each'
    lib/active_job/jobs_relation.rb:31:in 'Enumerable#to_a'
    lib/active_job/jobs_relation.rb:31:in 'ActiveJob::JobsRelation#last'
    test/active_job/queue_adapters/adapter_testing/job_details.rb:9:in 'block in <module:JobDetails>'
```