### PR TITLE
Truncate string arguments displayed in failed jobs index

### DIFF
--- a/app/views/mission_control/jobs/jobs/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/_job.html.erb
@@ -3,7 +3,7 @@
     <%= link_to job_title(job), application_job_path(@application, job.job_id) %>
 
     <% if job.serialized_arguments.present? %>
-      <div class="is-family-monospace"><%= job_arguments(job) %></div>
+      <div class="is-family-monospace"><%= truncate(job_arguments(job), length: 300) %></div>
     <% end %>
 
     <div class="has-text-grey is-size-7">Enqueued <%= time_distance_in_words_with_title(job.enqueued_at.to_datetime) %> ago</div>

--- a/app/views/mission_control/jobs/queues/_job.html.erb
+++ b/app/views/mission_control/jobs/queues/_job.html.erb
@@ -8,7 +8,7 @@
   <td>
     <% if job.serialized_arguments.present? %>
       <span class="is-family-monospace">
-        <%= job_arguments(job) %>
+        <%= truncate(job_arguments(job), length: 300) %>
       </span>
     <% end %>
   </td>

--- a/app/views/mission_control/jobs/shared/_job.html.erb
+++ b/app/views/mission_control/jobs/shared/_job.html.erb
@@ -8,7 +8,7 @@
   <td>
     <% if job.serialized_arguments.present? %>
       <span class="is-family-monospace">
-        <%= job_arguments(job) %>
+        <%= truncate(job_arguments(job), length: 300) %>
       </span>
     <% end %>
   </td>

--- a/app/views/mission_control/jobs/workers/_worker.html.erb
+++ b/app/views/mission_control/jobs/workers/_worker.html.erb
@@ -11,7 +11,7 @@
         <%= link_to job_title(job), application_job_path(@application, job.job_id) %>
 
         <% if job.serialized_arguments.present? %>
-          <div class="is-family-monospace is-size-7"><%= job_arguments(job) %></div>
+          <div class="is-family-monospace is-size-7"><%= truncate(job_arguments(job), length: 300) %></div>
         <% end %>
       </div>
     <% end %>

--- a/test/controllers/queues_controller_test.rb
+++ b/test/controllers/queues_controller_test.rb
@@ -22,6 +22,19 @@ class MissionControl::Jobs::QueuesControllerTest < ActionDispatch::IntegrationTe
     assert_select "tbody td", "1"
   end
 
+  test "truncate long job arguments in the queue's job list" do
+    job = DummyJob.perform_later("a" * 1000)
+
+    get mission_control_jobs.application_queue_url(@application, "default")
+    assert_response :ok
+    assert_select "tr.job", /a{297}\.\.\./
+    assert_no_match(/a{298}/, response.body)
+
+    get mission_control_jobs.application_job_url(@application, job.job_id)
+    assert_response :ok
+    assert_includes response.body, "a" * 1000
+  end
+
   test "turbo prefetch is disabled" do
     get mission_control_jobs.application_queues_url(@application)
 


### PR DESCRIPTION
## Description:
This PR truncates the string representation of job arguments in the failed jobs index view. When job arguments are very long, they can break the UI and make the job list hard to read. With this change, only the first 300 characters are shown in the index, while the full arguments remain visible in the job detail view.

## Why:
This improves readability and usability. Currently, when job arguments are too long, the UI tends to break and requires excessive horizontal scrolling to perform actions like retry or discard, making the process tedious. Alternatively, users are forced to enter the job detail view just to take action, which is inefficient. Truncating the arguments in the index view makes it much easier to quickly navigate, scan, and manage failed jobs.