### PR TITLE
Adds turbo stream to the discard button jobs

### DIFF
--- a/app/controllers/mission_control/jobs/discards_controller.rb
+++ b/app/controllers/mission_control/jobs/discards_controller.rb
@@ -3,7 +3,10 @@ class MissionControl::Jobs::DiscardsController < MissionControl::Jobs::Applicati
 
   def create
     @job.discard
-    redirect_to redirect_location, notice: "Discarded job with id #{@job.job_id}"
+    respond_to do |format|
+      format.html { redirect_to redirect_location, notice: "Discarded job with id #{@job.job_id}" }
+      format.turbo_stream { render turbo_stream: turbo_stream.remove("job_#{@job.job_id}") }
+    end
   end
 
   private

--- a/app/views/mission_control/jobs/jobs/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/_job.html.erb
@@ -1,4 +1,4 @@
-<tr class="job">
+<tr class="job" id="job_<%= job.job_id %>">
   <td>
     <%= link_to job_title(job), application_job_path(@application, job.job_id) %>
 

--- a/app/views/mission_control/jobs/jobs/failed/_actions.html.erb
+++ b/app/views/mission_control/jobs/jobs/failed/_actions.html.erb
@@ -1,5 +1,5 @@
 <div class="buttons is-right">
   <%= button_to "Discard", application_job_discard_path(@application, job.job_id), class: "button is-danger is-light mr-0",
-    form: { data: { turbo_confirm: "This will delete the job and can't be undone. Are you sure?" } } %>
+    form: { data: { turbo_stream: true, turbo_confirm: "This will delete the job and can't be undone. Are you sure?" } } %>
   <%= button_to "Retry", application_job_retry_path(@application, job.job_id), class: "button is-warning is-light mr-0" %>
 </div>


### PR DESCRIPTION
Fixes issue #161 where the full refresh would clear the current job class filter, uses turbo-stream true on the discard button to remove the table row without hard refresh.

### Solution

This is a proof of concept using turbo streams, because we would like @rosa 's feedback on the approach.
An alternative solution is passing the current parameters into the discard button like so, but this has it's drawbacks as well.

### Steps to test

- Create some failed jobs of separate classes
- Apply the filter in the view
- Discard a job, check that it is deleted successfully and is removed from the view
- The filter for the job class remains

### Known issues

- This PR doesnt update the count of filtered jobs on the view, because it skips re-render. 
<img width="400" alt="Screenshot 2025-07-09 at 2 16 32 PM" src="https://github.com/user-attachments/assets/b71bf4a5-510b-4f1b-8a2a-c91d8f643ca3" />

This can be solved by updating the count as well using the turbo_stream `.replace` method within a `turbo_stream.html`
If we want to go forward with this approach, we should fix this known issue and add test coverage
- The flash doesnt render (also Todo)