### PR TITLE
Keep around the current filter in query parameter for Discarding failed jobs

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/job_filters.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_filters.rb
@@ -4,7 +4,7 @@ module MissionControl::Jobs::JobFilters
   included do
     before_action :set_filters
 
-    helper_method :active_filters?
+    helper_method :active_filters?, :jobs_filter_param
   end
 
   private
@@ -18,6 +18,14 @@ module MissionControl::Jobs::JobFilters
 
     def active_filters?
       @job_filters.any?
+    end
+
+    def jobs_filter_param
+      if @job_filters&.any?
+        { filter: @job_filters }
+      else
+        {}
+      end
     end
 
     def finished_at_range_params

--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -12,6 +12,7 @@ class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_co
   include MissionControl::Jobs::BasicAuthentication
   include MissionControl::Jobs::ApplicationScoped, MissionControl::Jobs::NotFoundRedirections
   include MissionControl::Jobs::AdapterFeatures
+  include MissionControl::Jobs::JobFilters
 
   around_action :set_current_locale
 

--- a/app/controllers/mission_control/jobs/discards_controller.rb
+++ b/app/controllers/mission_control/jobs/discards_controller.rb
@@ -13,6 +13,6 @@ class MissionControl::Jobs::DiscardsController < MissionControl::Jobs::Applicati
 
     def redirect_location
       status = @job.status.presence_in(supported_job_statuses) || :failed
-      application_jobs_url(@application, status)
+      application_jobs_url(@application, status, **jobs_filter_param)
     end
 end

--- a/app/controllers/mission_control/jobs/jobs_controller.rb
+++ b/app/controllers/mission_control/jobs/jobs_controller.rb
@@ -1,5 +1,5 @@
 class MissionControl::Jobs::JobsController < MissionControl::Jobs::ApplicationController
-  include MissionControl::Jobs::JobScoped, MissionControl::Jobs::JobFilters
+  include MissionControl::Jobs::JobScoped
 
   skip_before_action :set_job, only: :index
 

--- a/app/controllers/mission_control/jobs/retries_controller.rb
+++ b/app/controllers/mission_control/jobs/retries_controller.rb
@@ -3,7 +3,7 @@ class MissionControl::Jobs::RetriesController < MissionControl::Jobs::Applicatio
 
   def create
     @job.retry
-    redirect_to application_jobs_url(@application, :failed), notice: "Retried job with id #{@job.job_id}"
+    redirect_to application_jobs_url(@application, :failed, **jobs_filter_param), notice: "Retried job with id #{@job.job_id}"
   end
 
   private

--- a/app/helpers/mission_control/jobs/navigation_helper.rb
+++ b/app/helpers/mission_control/jobs/navigation_helper.rb
@@ -37,14 +37,6 @@ module MissionControl::Jobs::NavigationHelper
     MissionControl::Jobs::Current.server.name == server.name
   end
 
-  def jobs_filter_param
-    if @job_filters&.any?
-      { filter: @job_filters }
-    else
-      {}
-    end
-  end
-
   def jobs_count_with_status(status)
     count = ActiveJob.jobs.with_status(status).count
     if count.infinite?

--- a/app/views/mission_control/jobs/jobs/failed/_actions.html.erb
+++ b/app/views/mission_control/jobs/jobs/failed/_actions.html.erb
@@ -1,5 +1,5 @@
 <div class="buttons is-right">
-  <%= button_to "Discard", application_job_discard_path(@application, job.job_id, params: params.permit!), class: "button is-danger is-light mr-0",
+  <%= button_to "Discard", application_job_discard_path(@application, job.job_id, params: jobs_filter_param), class: "button is-danger is-light mr-0",
     form: { data: { turbo_confirm: "This will delete the job and can't be undone. Are you sure?" } } %>
-  <%= button_to "Retry", application_job_retry_path(@application, job.job_id, params: params.permit!), class: "button is-warning is-light mr-0" %>
+  <%= button_to "Retry", application_job_retry_path(@application, job.job_id, params: jobs_filter_param), class: "button is-warning is-light mr-0" %>
 </div>


### PR DESCRIPTION
Solves #161 by adding the current parameters to the discard button
Alternative to turbo stream solution proposed in #270
### Solution

Add the current parameters to the discard button path, with `params: params.permit!` 

<img width="1559" alt="Screenshot 2025-07-09 at 8 22 26 PM" src="https://github.com/user-attachments/assets/53de89a3-6df4-433d-9f9d-f9f210c28bc4" />

Continue submitting params in the Discard and Retry buttons so that the next request keeps filter

### Steps to test

- Create some failed jobs of separate classes
- Apply the filter in the view
- Discard a job, check that it is deleted successfully and is removed from the view
- The filter for the job class remains selected in the next request

### Thoughts on this approach
After discussing some possible drawbacks of turbo for Discarding jobs in the view:
- Incorrect state of discarded job if the server is down
- rendering the flash message
- Handling update the Failed job count display

I've come to the conclusion that for solving the issue of the filter persisting keep the params with the Discard button submission.

The hard refresh on redirect comes with the benefit of
- immediate feedback of server uptime
- Complete re-render ensures latest state is displayed
- No maintenance of turbo streams required