### PR TITLE
fix: unescaped html in block job expiration text

### DIFF
--- a/app/helpers/mission_control/jobs/jobs_helper.rb
+++ b/app/helpers/mission_control/jobs/jobs_helper.rb
@@ -38,6 +38,10 @@ module MissionControl::Jobs::JobsHelper
     job.scheduled_at.before?(MissionControl::Jobs.scheduled_job_delay_threshold.ago)
   end
 
+  def blocked_job_expiration(job)
+    "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}".html_safe if job.blocked_until
+  end
+
   private
     def renderable_job_arguments_for(job)
       job.serialized_arguments.collect do |argument|

--- a/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
@@ -1,7 +1,7 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td>
   <div class="is-family-monospace is-size-7"><%= job.blocked_by %></div>
-  <div class="has-text-grey is-size-7"><%= job.blocked_until ? "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}" : "" %></div>
+  <div class="has-text-grey is-size-7"><%= blocked_job_expiration(job) %></div>
 </td>
 <td class="pr-0">
   <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -43,6 +43,17 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     assert_select "div.is-danger", "failed"
   end
 
+  test "get blocked jobs with their expiration" do
+    BlockingJob.perform_later(42)
+    BlockingJob.perform_later(43)
+
+    get mission_control_jobs.application_jobs_url(@application, :blocked)
+    assert_response :ok
+
+    assert_select "tr.job", 1
+    assert_select "tr.job span[title=?]", SolidQueue::BlockedExecution.last.expires_at.to_fs(:long), /in \d+ minutes/
+  end
+
   test "get finished jobs filtered by finished_at date" do
     [ "UTC", "International Date Line West" ].each do |timezone|
       Time.use_zone(timezone) do


### PR DESCRIPTION
The text was not marked html_safe thus it would render as `Expires <span title="July 12, 2025 19:55">10 minutes ago</span>` instead of `Expires 10 minutes ago` and show an tooltip with the exact time when hovered.

Before:
<img width="295" height="61" alt="image" src="https://github.com/user-attachments/assets/d14a10d4-c3f3-42c1-900d-2257b0104412" />

After:
<img width="313" height="178" alt="image" src="https://github.com/user-attachments/assets/c7327826-2590-4b1c-82cd-42cdc31bdb69" />

### Note:

Adding `.html_safe` within the helper would not work since you need to mark the whole interpolated string `"Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}"` as HTML safe. 

It would be kinda nice to not litter the view with that.
