### PR TITLE
Fix datetime shift in job filter for non-UTC timezones

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/job_filters.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_filters.rb
@@ -36,6 +36,6 @@ module MissionControl::Jobs::JobFilters
     end
 
     def parse_with_time_zone(date)
-      DateTime.parse(date).in_time_zone if date.present?
+      Time.zone.parse(date) if date.present?
     end
 end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -50,15 +50,15 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_select "tr.job", 1
 
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.from_now.to_s })
+    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
     assert_response :ok
     assert_select "tr.job", 0
 
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.ago.to_s, finished_at_end: 1.hour.from_now })
+    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.ago.strftime("%Y-%m-%dT%H:%M"), finished_at_end: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
     assert_response :ok
     assert_select "tr.job", 1
 
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_end: 1.hour.from_now })
+    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_end: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
     assert_response :ok
     assert_select "tr.job", 1
   end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -43,24 +43,28 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "get finished jobs filtered by finished_at date" do
-    job = DummyJob.perform_later(42)
-    perform_enqueued_jobs_async
+    ["UTC", "International Date Line West"].each do |timezone|
+      Time.use_zone(timezone) do
+        job = DummyJob.perform_later(42)
+        perform_enqueued_jobs_async
 
-    get mission_control_jobs.application_jobs_url(@application, :finished)
-    assert_response :ok
-    assert_select "tr.job", 1
+        get mission_control_jobs.application_jobs_url(@application, :finished)
+        assert_response :ok
+        assert_select "tr.job", 1
 
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
-    assert_response :ok
-    assert_select "tr.job", 0
+        get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
+        assert_response :ok
+        assert_select "tr.job", 0
 
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.ago.strftime("%Y-%m-%dT%H:%M"), finished_at_end: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
-    assert_response :ok
-    assert_select "tr.job", 1
+        get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_start: 1.hour.ago.strftime("%Y-%m-%dT%H:%M"), finished_at_end: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
+        assert_response :ok
+        assert_select "tr.job", 1
 
-    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_end: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
-    assert_response :ok
-    assert_select "tr.job", 1
+        get mission_control_jobs.application_jobs_url(@application, :finished, filter: { finished_at_end: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
+        assert_response :ok
+        assert_select "tr.job", 1
+      end
+    end
   end
 
   test "redirect to queue when job doesn't exist" do

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -43,7 +43,7 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "get finished jobs filtered by finished_at date" do
-    ["UTC", "International Date Line West"].each do |timezone|
+    [ "UTC", "International Date Line West" ].each do |timezone|
       Time.use_zone(timezone) do
         job = DummyJob.perform_later(42)
         perform_enqueued_jobs_async


### PR DESCRIPTION
## Problem

When Rails.application.config.time_zone is set to anything other than UTC, the datetime in the job filter shifts incorrectly each time it's edited.

For example, in my application where the timezone is set to Asia/Tokyo (+09:00), the time increases by 9 hours with every input.

https://github.com/user-attachments/assets/f5fd0df5-a30d-403a-a2b0-241d7b2c70e6

## Cause

The likely cause is how the datetime string is parsed.

The `form.datetime_field` submits a datetime string in the `%Y-%m-%dT%H:%M` format, which is then parsed by `DateTime.parse`. However, regardless of the application's time zone setting, this method defaults to parsing the string as UTC when no time zone information is provided.

## Solution

This pull request fixes the issue by parsing the datetime string in the application's configured time zone.