### PR TITLE
Fix "expires in" message in blocked jobs table

### DIFF
--- a/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
@@ -1,7 +1,7 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td>
   <div class="is-family-monospace is-size-7"><%= job.blocked_by %></div>
-  <div class="has-text-grey is-size-7"><%= job.blocked_until ? "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}" : "" %></div>
+  <div class="has-text-grey is-size-7"><%= job.blocked_until ? "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}".html_safe : "" %></div>
 </td>
 <td class="pr-0">
   <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>


### PR DESCRIPTION
The `bidirectional_time_distance_in_words_with_title` helper outputs a html-safe span tag. However it is used in string interpolation in the blocked jobs table making which is not html-safe by default resulting in the the raw html being displayed on the page.

This calls `#html_safe` on the string to not escape the markup.

Before the change:
<img width="515" height="178" alt="Screenshot 2025-10-08 at 4 40 30 PM" src="https://github.com/user-attachments/assets/26b89798-fcc1-45ad-b502-6d16a3a7d47b" />


After:
<img width="346" height="125" alt="Screenshot 2025-10-08 at 4 40 54 PM" src="https://github.com/user-attachments/assets/5c5c2fff-d154-4167-9677-0bd8d67ef2c4" />

