### PR TITLE
Add confirm to Retry buttons

### DIFF
--- a/app/views/mission_control/jobs/jobs/_toolbar.html.erb
+++ b/app/views/mission_control/jobs/jobs/_toolbar.html.erb
@@ -11,8 +11,8 @@
     <%= button_to "Discard #{target}", application_bulk_discards_path(@application, **jobs_filter_param),
       method: :post, disabled: jobs_count == 0, class: "button is-danger is-light",
       form: { data: { turbo_confirm: "This will delete #{jobs_count} jobs and can't be undone. Are you sure?" } } %>
-    <%= button_to "Retry #{target}", application_bulk_retries_path(@application, **jobs_filter_param),
-      method: :post, disabled: jobs_count == 0,
-      class: "button is-warning is-light mr-0" %>
+    <%= button_to "Retry #{target}", application_bulk_retries_path(@application, **jobs_filter_param), class: "button is-warning is-light mr-0", method: :post, disabled: jobs_count == 0,
+         form: { data: { turbo_confirm: "This will retry #{jobs_count} jobs. Are you sure?" } }
+       %>
   <% end %>
 </div>

--- a/app/views/mission_control/jobs/jobs/failed/_actions.html.erb
+++ b/app/views/mission_control/jobs/jobs/failed/_actions.html.erb
@@ -1,5 +1,8 @@
 <div class="buttons is-right">
   <%= button_to "Discard", application_job_discard_path(@application, job.job_id, params: jobs_filter_param), class: "button is-danger is-light mr-0",
     form: { data: { turbo_confirm: "This will delete the job and can't be undone. Are you sure?" } } %>
-  <%= button_to "Retry", application_job_retry_path(@application, job.job_id, params: jobs_filter_param), class: "button is-warning is-light mr-0" %>
+  <%= button_to "Retry", application_job_retry_path(@application, job.job_id, params: jobs_filter_param), class: "button is-warning is-light mr-0",
+    form: { data: { turbo_confirm: "This will retry the job. Are you sure?" } }
+
+  %>
 </div>

--- a/test/system/retry_jobs_test.rb
+++ b/test/system/retry_jobs_test.rb
@@ -14,7 +14,9 @@ class RetryJobsTest < ApplicationSystemTestCase
   test "retry all failed jobs" do
     assert_equal 9, job_row_elements.length
 
-    click_on "Retry all"
+    accept_confirm do
+      click_on "Retry all"
+    end
 
     assert_text "Retried 9 jobs"
     assert_empty job_row_elements
@@ -25,7 +27,9 @@ class RetryJobsTest < ApplicationSystemTestCase
     expected_job_id = ActiveJob.jobs.failed[2].job_id
 
     within_job_row "failing-arg-2" do
-      click_on "Retry"
+      accept_confirm do
+        click_on "Retry"
+      end
     end
 
     assert_text "Retried job with id #{expected_job_id}"
@@ -39,7 +43,10 @@ class RetryJobsTest < ApplicationSystemTestCase
     fill_in "filter[job_class_name]", with: "FailingJob"
     assert_text /6 jobs found/i
 
-    click_on "Retry selection"
+    accept_confirm do
+      click_on "Retry selection"
+    end
+
     assert_text /retried 6 jobs/i
     assert_equal 3, job_row_elements.length
   end
@@ -50,7 +57,10 @@ class RetryJobsTest < ApplicationSystemTestCase
     fill_in "filter[queue_name]", with: "queue_1"
     assert_text /4 jobs found/i
 
-    click_on "Retry selection"
+    accept_confirm do
+      click_on "Retry selection"
+    end
+
     assert_text /retried 4 jobs/i
     assert_equal 5, job_row_elements.length
   end
@@ -60,7 +70,9 @@ class RetryJobsTest < ApplicationSystemTestCase
     failed_job = ActiveJob.jobs.failed[2]
     visit job_path(failed_job.job_id)
 
-    click_on "Retry"
+    accept_confirm do
+      click_on "Retry"
+    end
 
     assert_text "Retried job with id #{failed_job.job_id}"
     assert_equal 8, job_row_elements.length


### PR DESCRIPTION
This MR adds the confirm prompt to the retry buttons. Currently a user can trigger a failed jobs with one misclick, which can cause old E-Mails to be sent etc. 