### PR TITLE
Fix #duration when #scheduled_at is `nil`

### DIFF
--- a/lib/active_job/job_proxy.rb
+++ b/lib/active_job/job_proxy.rb
@@ -27,7 +27,7 @@ class ActiveJob::JobProxy < ActiveJob::Base
   end
 
   def duration
-    finished_at - scheduled_at
+    finished_at - (scheduled_at || enqueued_at)
   end
 
   ActiveJob::JobsRelation::STATUSES.each do |status|

--- a/test/active_job/job_proxy_test.rb
+++ b/test/active_job/job_proxy_test.rb
@@ -6,4 +6,11 @@ class ActiveJob::JobProxyTest < ActiveSupport::TestCase
     job_proxy = ActiveJob::JobProxy.new(job.serialize)
     assert_instance_of DummyJob, ActiveJob::Base.deserialize(job_proxy.serialize)
   end
+
+  test "#duration does not break if scheduled_at is not set" do
+    job = DummyJob.new(123)
+    job_proxy = ActiveJob::JobProxy.new(job.serialize)
+    job_proxy.finished_at = job_proxy.enqueued_at + 5.seconds
+    assert_equal 5.seconds, job_proxy.duration 
+  end
 end

--- a/test/active_job/job_proxy_test.rb
+++ b/test/active_job/job_proxy_test.rb
@@ -11,6 +11,8 @@ class ActiveJob::JobProxyTest < ActiveSupport::TestCase
     job = DummyJob.new(123)
     job_proxy = ActiveJob::JobProxy.new(job.serialize)
     job_proxy.finished_at = job_proxy.enqueued_at + 5.seconds
+
+    assert_nil job_proxy.scheduled_at
     assert_equal 5.seconds, job_proxy.duration
   end
 end

--- a/test/active_job/job_proxy_test.rb
+++ b/test/active_job/job_proxy_test.rb
@@ -11,6 +11,6 @@ class ActiveJob::JobProxyTest < ActiveSupport::TestCase
     job = DummyJob.new(123)
     job_proxy = ActiveJob::JobProxy.new(job.serialize)
     job_proxy.finished_at = job_proxy.enqueued_at + 5.seconds
-    assert_equal 5.seconds, job_proxy.duration 
+    assert_equal 5.seconds, job_proxy.duration
   end
 end


### PR DESCRIPTION
## Problem

When a job is enqueued without `scheduled_at` being set the `app/views/mission_control/jobs/jobs/show.html.erb` template breaks as the `duration` calculation currently expects `scheduled_at` to have a value.

## Solution

Calculate the duration with `enqueued_at` if `scheduled_at` is `nil`.

Fixes #282 