### PR TITLE
Tweak wording in README's basic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   mount MissionControl::Jobs::Engine, at: "/jobs"
 ```
 
-And that's it. With this alone, you should be able to access Mission Control Job's UI, where you can browse the existing queues, jobs pending in these queues, jobs in different statuses, and discard and retry failed jobs:
+Once you set up [#authentication](Authentication), you should be able to access Mission Control Job's UI, where you can browse the existing queues, jobs pending in these queues, jobs in different statuses, and discard and retry failed jobs:
 
 ![Queues tab in a simple app](docs/images/queues-simple.png)
 


### PR DESCRIPTION
The current wording implies that Mission Control will work without authentication being set up, but this isn't true.