### PR TITLE
Update CI enviornment

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
@@ -29,21 +29,24 @@ jobs:
           bundle exec rubocop --parallel
 
   test:
-    name: Tests
+    name: Tests (Ruby ${{ matrix.ruby-version }}, ${{ matrix.gemfile }})
     runs-on: ubuntu-latest
     env:
       CI: true
       BUNDLE_GITHUB__COM: x-access-token:${{ secrets.GH_TOKEN }}
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['3.2', '3.3']
+        ruby-version: ['3.2', '3.3', '3.4']
+        gemfile: [rails_7_1, rails_7_2, rails_8_0, rails_8_1, rails_main]
     services:
       redis:
         image: redis:4.0-alpine
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rails", "~> 7.1.0"
+gem "capybara"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rails", "~> 7.2.0"
+gem "capybara"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rails", "~> 8.0.0"
+gem "capybara"

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rails", "~> 8.1.0"
+gem "capybara"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rails", github: "rails/rails", branch: "main"
+gem "capybara"


### PR DESCRIPTION
- Add Ruby3.4 to CI matrix
- Add Rails to the test matrix so that we now test all combinations from Rails 7.1 to 8.1 with Ruby 3.2 to 3.4
- Update actions/checkout to the latest version

test result is [here](https://github.com/willnet/mission_control-jobs/actions/runs/19844376906).