### PR TITLE
Fix config.active_job.default_page_size not being applied

### DIFF
--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -39,7 +39,7 @@ module MissionControl
         MissionControl::Jobs.http_basic_auth_password ||= app.credentials.dig(:mission_control, :http_basic_auth_password)
       end
 
-      initializer "mission_control-jobs.active_job.extensions" do
+      initializer "mission_control-jobs.active_job.extensions", before: "active_job.set_configs" do
         ActiveSupport.on_load :active_job do
           include ActiveJob::Querying
           include ActiveJob::Executing

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -48,6 +48,7 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
   config.active_job.queue_adapter = :resque
+  config.active_job.default_page_size = 50
 
   config.solid_queue.connects_to = { database: { writing: :queue } }
 

--- a/test/mission_control/jobs/engine_test.rb
+++ b/test/mission_control/jobs/engine_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class MissionControl::Jobs::EngineTest < ActiveSupport::TestCase
+  test "applies configured default_page_size" do
+    assert_equal 50, ActiveJob::Base.default_page_size
+    assert_equal 50, ActiveJob.jobs.default_page_size
+  end
+end


### PR DESCRIPTION
Fixes #294

The `config.active_job.default_page_size` setting wasn’t being applied because the `default_page_size` attribute didn’t exist yet when Rails ran the `active_job.set_configs` initializer. Adding `before: "active_job.set_configs"` to the initializer ensures the attribute is defined early enough for Rails to apply the configuration.