### PR TITLE
Ignore surrounding white spaces when filtering by job class name or queue

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/job_filters.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_filters.rb
@@ -10,8 +10,8 @@ module MissionControl::Jobs::JobFilters
   private
     def set_filters
       @job_filters = {
-        job_class_name: params.dig(:filter, :job_class_name).presence,
-        queue_name: params.dig(:filter, :queue_name).presence,
+        job_class_name: params.dig(:filter, :job_class_name).to_s.strip.presence,
+        queue_name: params.dig(:filter, :queue_name).to_s.strip.presence,
         finished_at: finished_at_range_params
       }.compact
     end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
   setup do
     DummyJob.queue_as :queue_1
+    DummyReloadedJob.queue_as :queue_2
   end
 
   test "get job details" do
@@ -134,5 +135,39 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr.job", /DummyJob\s+Enqueued less than 5 seconds ago\s+queue_1\s+in 3 minutes/
   ensure
     I18n.available_locales = previous_locales
+  end
+
+  test "empty string after stripping whitespace does not filter" do
+    DummyJob.perform_later(42)
+    DummyReloadedJob.perform_later(42)
+    perform_enqueued_jobs_async
+
+    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { job_class_name: " \n\t \n\t" })
+    assert_response :ok
+    assert_select "tr.job", 2
+    assert_select "tr.job", /DummyJob/
+    assert_select "tr.job", /DummyReloadedJob/
+  end
+
+  test "get jobs filtered by class name ignoring surrounding white spaces, newlines and tabs" do
+    DummyJob.perform_later(42)
+    DummyReloadedJob.perform_later(42)
+    perform_enqueued_jobs_async
+
+    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { job_class_name: " \n\tDummyJob \n\t" })
+    assert_response :ok
+    assert_select "tr.job", 1
+    assert_select "tr.job", /DummyJob/
+  end
+
+  test "get jobs filtered by queue name ignoring surrounding white spaces, newlines and tabs" do
+    DummyJob.perform_later(42)
+    DummyReloadedJob.perform_later(42)
+    perform_enqueued_jobs_async
+
+    get mission_control_jobs.application_jobs_url(@application, :finished, filter: { queue_name: " \n\tqueue_1 \n\t" })
+    assert_response :ok
+    assert_select "tr.job", 1
+    assert_select "tr.job", /DummyJob/
   end
 end


### PR DESCRIPTION
Fix: filtering by job class name or queue and including white spaces surrounding the input text will result in a mismatch even if the text matches jobs present in the database.

Adding #strip to the search params prevents this from happening. 