### PR TITLE
Use ActionController::Base as default base_controller_class

### DIFF
--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -15,7 +15,7 @@ module MissionControl
   module Jobs
     mattr_accessor :adapters, default: Set.new
     mattr_accessor :applications, default: MissionControl::Jobs::Applications.new
-    mattr_accessor :base_controller_class, default: "::ApplicationController"
+    mattr_accessor :base_controller_class, default: "ActionController::Base"
 
     mattr_accessor :internal_query_count_limit, default: 500_000 # Hard limit to keep unlimited count queries fast enough
     mattr_accessor :delay_between_bulk_operation_batches, default: 0


### PR DESCRIPTION
Prevents conflicts with custom authentication code defined in
the host application's `ApplicationController`.

Closes #245