### PR TITLE
use default_url_options from base_controller_class

### DIFF
--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -18,7 +18,7 @@ class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_co
 
   private
     def default_url_options
-      { server_id: MissionControl::Jobs::Current.server }
+      super.merge(server_id: MissionControl::Jobs::Current.server)
     end
 
     def set_current_locale(&block)


### PR DESCRIPTION
Enable inheritance of default_url_options from the base_controller_class. This is important, for example, if you need to preassign placeholders in root_url for the general app.