### PR TITLE
Use turbo_frame to update job backtrace view

### DIFF
--- a/app/views/mission_control/jobs/jobs/_error_information.html.erb
+++ b/app/views/mission_control/jobs/jobs/_error_information.html.erb
@@ -14,9 +14,11 @@
     </tbody>
   </table>
 
-  <% if @server.backtrace_cleaner %>
-    <%= render "mission_control/jobs/jobs/failed/backtrace_toggle", application: @application, job: job %>
-  <% end %>
+  <%= turbo_frame_tag "job-backtrace" do %>
+    <% if @server.backtrace_cleaner %>
+      <%= render "mission_control/jobs/jobs/failed/backtrace_toggle", application: @application, job: job %>
+    <% end %>
 
-  <pre class="is-family-monospace mb-4 backtrace-content"><%= failed_job_backtrace(job, @server) %></pre>
+    <pre class="is-family-monospace mb-4 backtrace-content"><%= failed_job_backtrace(job, @server) %></pre>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Wrap section of failed job partial in turbo_frame tag to make the transition smoother when clicking in either "Clean" or "Full" backtrace buttons.