### PR TITLE
Add option to customize "Back to main app" path

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Besides `base_controller_class`, you can also set the following for `MissionCont
 - `internal_query_count_limit`: in count queries, the maximum number of records that will be counted if the adapter needs to limit these queries. True counts above this number will be returned as `INFINITY`. This keeps count queries fast—defaults to `500,000`
 - `scheduled_job_delay_threshold`: the time duration before a scheduled job is considered delayed. Defaults to `1.minute` (a job is considered delayed if it hasn't transitioned from the `scheduled` status 1 minute after the scheduled time).
 - `show_console_help`: whether to show the console help. If you don't want the console help message, set this to `false`—defaults to `true`.
+- `back_to_main_app_path`: an optional string path for the "Back to main app" link. Example: `'/admin'`. Defaults to the host app's `root_path` when available.
 - `backtrace_cleaner`: a backtrace cleaner used for optionally filtering backtraces on the Failed Jobs detail page. Defaults to `Rails::BacktraceCleaner.new`. See the [Advanced configuration](#advanced-configuration) section for how to configure/override this setting on a per application/server basis.
 - `filter_arguments`: an array of strings representing the job argument keys you want to filter out in the UI. This is useful for hiding sensitive user data. Currently, only root-level hash keys are supported.
 

--- a/app/helpers/mission_control/jobs/navigation_helper.rb
+++ b/app/helpers/mission_control/jobs/navigation_helper.rb
@@ -1,6 +1,10 @@
 module MissionControl::Jobs::NavigationHelper
   attr_reader :page_title, :current_section
 
+  def back_to_main_app_path
+    MissionControl::Jobs.back_to_main_app_path.presence || main_app.try(:root_path)
+  end
+
   def navigation_sections
     { queues: [ "Queues", application_queues_path(@application) ] }.tap do |sections|
       supported_job_statuses.without(:pending).each do |status|

--- a/app/views/layouts/mission_control/jobs/_application_selection.html.erb
+++ b/app/views/layouts/mission_control/jobs/_application_selection.html.erb
@@ -1,8 +1,8 @@
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-menu is-active mb-4">
     <div class="navbar-start">
-      <% if defined?(main_app.root_path) %>
-        <%= link_to "Back to main app", main_app.root_path %>
+      <% if (path = back_to_main_app_path) %>
+        <%= link_to "Back to main app", path %>
       <% end %>
     </div>
 

--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -25,6 +25,7 @@ module MissionControl
 
     mattr_accessor :show_console_help, default: true
     mattr_accessor :backtrace_cleaner
+    mattr_accessor :back_to_main_app_path
 
     mattr_accessor :importmap, default: Importmap::Map.new
 

--- a/test/helpers/navigation_helper_test.rb
+++ b/test/helpers/navigation_helper_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class MissionControl::Jobs::NavigationHelperTest < ActionView::TestCase
+  tests MissionControl::Jobs::NavigationHelper
+
+  setup do
+    @original_back_to_main_app_path = MissionControl::Jobs.back_to_main_app_path
+  end
+
+  teardown do
+    MissionControl::Jobs.back_to_main_app_path = @original_back_to_main_app_path
+  end
+
+  test "returns configured back link destination when set" do
+    MissionControl::Jobs.back_to_main_app_path = "/admin"
+
+    stubs(:main_app).returns(stub(root_path: "/"))
+
+    assert_equal "/admin", back_to_main_app_path
+  end
+
+  test "falls back to main app root path when no override is configured" do
+    stubs(:main_app).returns(stub(root_path: "/"))
+
+    assert_equal "/", back_to_main_app_path
+  end
+
+  test "returns nil when no override is configured and main app does not expose root path" do
+    stubs(:main_app).returns(Object.new)
+
+    assert_nil back_to_main_app_path
+  end
+end

--- a/test/system/list_queues_test.rb
+++ b/test/system/list_queues_test.rb
@@ -15,4 +15,21 @@ class ListQueuesTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test "back to main app points to root path by default" do
+    visit queues_path
+
+    assert_equal "/", URI.parse(find_link("Back to main app")[:href]).path
+  end
+
+  test "back to main app points to configured override path" do
+    original_back_to_main_app_path = MissionControl::Jobs.back_to_main_app_path
+    MissionControl::Jobs.back_to_main_app_path = "/admin"
+
+    visit queues_path
+
+    assert_equal "/admin", URI.parse(find_link("Back to main app")[:href]).path
+  ensure
+    MissionControl::Jobs.back_to_main_app_path = original_back_to_main_app_path
+  end
 end


### PR DESCRIPTION
- Add `config.mission_control.back_to_main_app_path` config option to customize where "Back to main app" button links to.
- Ex: `MissionControl::Jobs.back_to_main_app_path = "/admin"`