### PR TITLE
Improve jobs filtering and don't refresh page when user types.

### DIFF
--- a/app/javascript/mission_control/jobs/application.js
+++ b/app/javascript/mission_control/jobs/application.js
@@ -1,4 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
-import "helpers"

--- a/app/javascript/mission_control/jobs/controllers/form_controller.js
+++ b/app/javascript/mission_control/jobs/controllers/form_controller.js
@@ -1,21 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
-import { debounce } from "helpers"
 
 export default class extends Controller {
-  static values = {
-    debounceTimeout: { type: Number, default: 300 }
-  }
-
-  initialize() {
-    this.debouncedSubmit = debounce(this.debouncedSubmit.bind(this), this.debounceTimeoutValue)
-  }
-
   submit(event) {
     const form = event.target.form || event.target.closest("form")
     if (form) form.requestSubmit()
-  }
-
-  debouncedSubmit(event) {
-    this.submit(event)
   }
 }

--- a/app/javascript/mission_control/jobs/helpers/debounce_helpers.js
+++ b/app/javascript/mission_control/jobs/helpers/debounce_helpers.js
@@ -1,9 +1,0 @@
-export function debounce(fn, delay = 10) {
-  let timeoutId = null
-
-  return (...args) => {
-    const callback = () => fn.apply(this, args)
-    clearTimeout(timeoutId)
-    timeoutId = setTimeout(callback, delay)
-  }
-}

--- a/app/javascript/mission_control/jobs/helpers/index.js
+++ b/app/javascript/mission_control/jobs/helpers/index.js
@@ -1,1 +1,0 @@
-export * from "helpers/debounce_helpers"

--- a/app/views/mission_control/jobs/jobs/_filters.html.erb
+++ b/app/views/mission_control/jobs/jobs/_filters.html.erb
@@ -1,6 +1,6 @@
 <div class="filter level-left">
   <%= form_for :filter, url: application_jobs_path(MissionControl::Jobs::Current.application, jobs_status), method: :get,
-    data: { controller: "form", action: "input->form#debouncedSubmit" } do |form| %>
+    data: { controller: "form", action: "change->form#submit" } do |form| %>
 
     <div class="field is-grouped">
       <div class="control">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,4 +3,3 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from MissionControl::Jobs::Engine.root.join("app/javascript/mission_control/jobs/controllers"), under: "controllers", to: "mission_control/jobs/controllers"
-pin_all_from MissionControl::Jobs::Engine.root.join("app/javascript/mission_control/jobs/helpers"), under: "helpers", to: "mission_control/jobs/helpers"

--- a/test/system/discard_jobs_test.rb
+++ b/test/system/discard_jobs_test.rb
@@ -40,6 +40,7 @@ class DiscardJobsTest < ApplicationSystemTestCase
     assert_equal 9, job_row_elements.length
 
     fill_in "filter[job_class_name]", with: "FailingReloadedJob"
+    send_keys :tab
     assert_text /3 jobs found/i
 
     accept_confirm do
@@ -54,6 +55,7 @@ class DiscardJobsTest < ApplicationSystemTestCase
     assert_equal 9, job_row_elements.length
 
     fill_in "filter[queue_name]", with: "queue_2"
+    send_keys :tab
     assert_text /5 jobs found/i
 
     accept_confirm do

--- a/test/system/retry_jobs_test.rb
+++ b/test/system/retry_jobs_test.rb
@@ -37,6 +37,7 @@ class RetryJobsTest < ApplicationSystemTestCase
     assert_equal 9, job_row_elements.length
 
     fill_in "filter[job_class_name]", with: "FailingJob"
+    send_keys :tab
     assert_text /6 jobs found/i
 
     click_on "Retry selection"
@@ -48,6 +49,7 @@ class RetryJobsTest < ApplicationSystemTestCase
     assert_equal 9, job_row_elements.length
 
     fill_in "filter[queue_name]", with: "queue_1"
+    send_keys :tab
     assert_text /4 jobs found/i
 
     click_on "Retry selection"


### PR DESCRIPTION
Many times I run into scenario when I wanted to filter jobs, but I cannot see its name in data list and I recalled just part of it. Current behaviour, when form is submitted (even with delay) automatically in my opinion removes benefits of `datalist` filtering.

- Replace `input->form#debouncedSubmit` with `change->form#submit` on the job filters form.
- The input event fires on every keystroke, causing repeated page refreshes (and losing focus) while the user is still typing into the job class name or queue name fields.
- The change event fires only when the user finishes editing (blur or datalist selection), resulting in a single clean submit.
- Update system tests to `send_keys :tab` after `fill_in` to trigger the change event, matching realistic user behavior.