### PR TITLE
Add queue latency to the queues index

### DIFF
--- a/app/views/mission_control/jobs/queues/_queue.html.erb
+++ b/app/views/mission_control/jobs/queues/_queue.html.erb
@@ -8,6 +8,9 @@
   <td>
     <%= queue.size %>
   </td>
+  <td>
+    <%= ActiveSupport::Duration.build(queue.latency).inspect %>
+  </td>
   <td class="pr-0">
     <% if queue_pausing_supported? %>
       <%= render "mission_control/jobs/queues/actions", queue: queue %>

--- a/app/views/mission_control/jobs/queues/index.html.erb
+++ b/app/views/mission_control/jobs/queues/index.html.erb
@@ -6,6 +6,7 @@
   <tr>
     <th>Queue</th>
     <th>Pending jobs</th>
+    <th>Latency</th>
     <th></th>
   </tr>
   </thead>

--- a/lib/active_job/querying.rb
+++ b/lib/active_job/querying.rb
@@ -22,7 +22,7 @@ module ActiveJob::Querying
     private
       def fetch_queues
         queue_adapter.queues.collect do |queue|
-          ActiveJob::Queue.new(queue[:name], size: queue[:size], active: queue[:active], queue_adapter: queue_adapter)
+          ActiveJob::Queue.new(queue[:name], size: queue[:size], active: queue[:active], latency: queue[:latency], queue_adapter: queue_adapter)
         end
       end
   end

--- a/lib/active_job/queue.rb
+++ b/lib/active_job/queue.rb
@@ -2,12 +2,13 @@
 class ActiveJob::Queue
   attr_reader :name
 
-  def initialize(name, size: nil, active: nil, queue_adapter: ActiveJob::Base.queue_adapter)
+  def initialize(name, size: nil, active: nil, latency: nil, queue_adapter: ActiveJob::Base.queue_adapter)
     @name = name
     @queue_adapter = queue_adapter
 
     @size = size
     @active = active
+    @latency = latency
   end
 
   def size
@@ -15,6 +16,10 @@ class ActiveJob::Queue
   end
 
   alias length size
+
+  def latency
+    @latency ||= queue_adapter.queue_latency(name)
+  end
 
   def clear
     queue_adapter.clear_queue(name)
@@ -47,7 +52,7 @@ class ActiveJob::Queue
   end
 
   def reload
-    @active = @size = nil
+    @active = @size = @latency = nil
     self
   end
 

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -10,6 +10,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
       {
         name: queue.name,
         size: queue.size,
+        latency: queue.latency,
         active: pauses[queue.name].nil?
       }
     end
@@ -17,6 +18,10 @@ module ActiveJob::QueueAdapters::SolidQueueExt
 
   def queue_size(queue_name)
     find_queue_by_name(queue_name).size
+  end
+
+  def queue_latency(queue_name)
+    find_queue_by_name(queue_name).latency
   end
 
   def clear_queue(queue_name)

--- a/lib/mission_control/jobs/adapter.rb
+++ b/lib/mission_control/jobs/adapter.rb
@@ -95,6 +95,10 @@ module MissionControl::Jobs::Adapter
     raise_incompatible_adapter_error_from :queue_size
   end
 
+  def queue_latency(queue_name)
+    raise_incompatible_adapter_error_from :queue_latency
+  end
+
   def clear_queue(queue_name)
     raise_incompatible_adapter_error_from :clear_queue
   end

--- a/test/active_job/queue_adapters/adapter_testing/queues.rb
+++ b/test/active_job/queue_adapters/adapter_testing/queues.rb
@@ -45,6 +45,13 @@ module ActiveJob::QueueAdapters::AdapterTesting::Queues
     assert_equal 3, queue.length
   end
 
+  test "queue latency" do
+    3.times { DynamicQueueJob("queue_1").perform_later }
+
+    queue = ActiveJob.queues[:queue_1]
+    assert_kind_of Numeric, queue.latency
+  end
+
   test "queue sizes for multiple queues" do
     3.times { DynamicQueueJob("queue_1").perform_later }
     5.times { DynamicQueueJob("queue_2").perform_later }


### PR DESCRIPTION
## Background

The queues index page currently shows the queue name, pending job count, and pause status. There is no visibility into how long jobs are waiting before being picked up. 

Solid Queue already calculates latency natively as the age of the oldest ready execution in a queue, so this delegates to that existing method rather than reimplementing the calculation.

## Changes

The adapter interface in adapter.rb gains a queue_latency method that follows the same pattern as queue_size. The Solid Queue adapter implements this by delegating to SolidQueue::Queue#latency, both for single queue lookups and for the bulk queue listing on the index page.

The Queue model in queue.rb picks up a latency attribute that can be pre-loaded from the index or lazily fetched for a single queue, avoiding N+1 queries. querying.rb passes latency through when constructing Queue objects from the adapter data.

The queues index view adds a Latency column displaying a human-readable duration via ActiveSupport::Duration.

## Test plan

A new adapter test verifies that queue.latency returns a numeric value, following the pattern of the existing queue size test.