### PR TITLE
Change blocked_until rendering to use safe output

### DIFF
--- a/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
@@ -1,7 +1,7 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td>
   <div class="is-family-monospace is-size-7"><%= job.blocked_by %></div>
-  <div class="has-text-grey is-size-7"><%= job.blocked_until ? "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}" : "" %></div>
+  <div class="has-text-grey is-size-7"><%== job.blocked_until ? "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}" : "" %></div>
 </td>
 <td class="pr-0">
   <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>

--- a/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
@@ -1,7 +1,7 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td>
   <div class="is-family-monospace is-size-7"><%= job.blocked_by %></div>
-  <div class="has-text-grey is-size-7"><%== job.blocked_until ? "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}" : "" %></div>
+  <div class="has-text-grey is-size-7"><%= job.blocked_until ? "Expires #{bidirectional_time_distance_in_words_with_title(job.blocked_until)}".html_safe : "" %></div>
 </td>
 <td class="pr-0">
   <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>


### PR DESCRIPTION
Hello guys, simple PR to fix a raw HTML in blocked job partial, because of interpolation.
Tested locally, works good.
I saw another open PR, but it is stale from 2025 (2026 nowadays), but issue still actual, let's fix it, because people use this gem and have this issue 😄.
If you have any comments, or questions - just ask. But I am not sure so simple PR can hesitate you to merge it.

Btw, don't forget to restart your web server when you will try to test this change (if you will).

Issue:
<img width="2940" height="1840" alt="CleanShot 2026-04-25 at 5  45 25@2x" src="https://github.com/user-attachments/assets/42d33e43-f3c2-4ba6-bd99-268f9a4fb1ca" />
