### PR TITLE
Parenthesize splat arguments to avoid ambiguity warnings

### DIFF
--- a/lib/active_job/jobs_relation.rb
+++ b/lib/active_job/jobs_relation.rb
@@ -26,7 +26,7 @@ class ActiveJob::JobsRelation
   FILTERS = %i[ queue_name job_class_name ]
 
   PROPERTIES = %i[ queue_name status offset_value limit_value job_class_name worker_id recurring_task_id finished_at ]
-  attr_reader *PROPERTIES, :default_page_size
+  attr_reader(*PROPERTIES, :default_page_size)
 
   delegate :last, :[], :reverse, to: :to_a
   delegate :logger, to: MissionControl::Jobs
@@ -61,7 +61,7 @@ class ActiveJob::JobsRelation
       finished_at: finished_at
     }.compact
 
-    clone_with **arguments
+    clone_with(**arguments)
   end
 
   def with_status(status)
@@ -219,7 +219,7 @@ class ActiveJob::JobsRelation
 
   private
     attr_reader :queue_adapter, :loaded_jobs
-    attr_writer *PROPERTIES
+    attr_writer(*PROPERTIES)
 
     def set_defaults
       self.offset_value = 0

--- a/test/active_job/jobs_relation_test.rb
+++ b/test/active_job/jobs_relation_test.rb
@@ -59,6 +59,12 @@ class ActiveJob::JobsRelationTest < ActiveSupport::TestCase
     end
   end
 
+  test "source file parses without warnings in verbose mode" do
+    source_path = Object.const_source_location("ActiveJob::JobsRelation").first
+    output = `#{Gem.ruby} -wc "#{source_path}" 2>&1`
+    assert_equal "Syntax OK", output.strip
+  end
+
   test "caches the count of jobs" do
     ActiveJob::Base.queue_adapter.expects(:jobs_count).once.returns(2)
     ActiveJob::Base.queue_adapter.expects(:supports_job_filter?).at_least_once.returns(true)


### PR DESCRIPTION
### Summary
Requiring the gem under a verbose Ruby (e.g. any test suite run with warnings enabled on Ruby 3.4/4.x) emits three "ambiguous `*`/`**` has been interpreted as an argument prefix" warnings from `lib/active_job/jobs_relation.rb`. Wrapping the three argument lists in parentheses silences the warnings with no behavior change.

Fixes #318

### Root cause
Three call sites pass splatted arguments without parentheses, so the parser cannot tell the splat from a binary operator and warns in verbose mode:

- `lib/active_job/jobs_relation.rb:29` — `attr_reader *PROPERTIES, :default_page_size`
- `lib/active_job/jobs_relation.rb:64` — `clone_with **arguments`
- `lib/active_job/jobs_relation.rb:222` — `attr_writer *PROPERTIES`

### Solution
Parenthesize the three argument lists, exactly as suggested in the issue. Purely syntactic; the parsed semantics are identical.

### Tests
- Added a regression test to `test/active_job/jobs_relation_test.rb` that runs `ruby -wc` against the file and asserts the only output is `Syntax OK`, so any future ambiguity (or other parse) warning in this file fails the suite. Happy to drop it if you consider it overkill for a syntax-only fix.
- Commands run: `bin/rails test test/active_job/jobs_relation_test.rb`, `bin/rails test` (227 runs, 0 failures; 1 pre-existing adapter-conditional skip), `bundle exec rubocop --parallel` (clean).
- Regression test fails without the fix: it captures the exact three warnings from the issue (`lib/active_job/jobs_relation.rb:29/64/222: warning: ambiguous ...`).

### QA
N/A — covered by tests. Verified manually that `ruby -wc lib/active_job/jobs_relation.rb` prints only `Syntax OK` after the change (Ruby 3.4.8).

### Risks
None identified — parse-level change with identical semantics; adapter-agnostic; no public API or default behavior touched.

### Checklist
- [x] Requirement confirmed against the issue
- [x] Root cause identified
- [x] Smallest possible diff
- [x] Regression test added (fails before, passes after)
- [x] Existing tests pass
- [x] Adapter behavior reviewed (Resque + Solid Queue — change is adapter-agnostic)
- [x] Docs reviewed (no README impact)
- [x] No unrelated cleanup
- [x] Opened as draft
