### PR TITLE
Show the raw error when a failed execution's error can't be parsed

### DIFF
--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -127,6 +127,11 @@ module ActiveJob::QueueAdapters::SolidQueueExt
           message: solid_queue_job.failed_execution.message,
           backtrace: solid_queue_job.failed_execution.backtrace || []
       end
+    rescue JSON::ParserError
+      ActiveJob::ExecutionError.new \
+        error_class: "",
+        message: solid_queue_job.failed_execution.error_before_type_cast,
+        backtrace: []
     end
 
     def dispatch_immediately(job)

--- a/test/active_job/queue_adapters/solid_queue_test.rb
+++ b/test/active_job/queue_adapters/solid_queue_test.rb
@@ -8,6 +8,19 @@ class ActiveJob::QueueAdapters::SolidQueueTest < ActiveSupport::TestCase
     SolidQueue.logger = ActiveSupport::Logger.new(nil)
   end
 
+  test "expose the raw error when the failed execution error can't be parsed" do
+    FailingJob.perform_later
+    perform_enqueued_jobs
+
+    SolidQueue::FailedExecution.update_all("error = 'RuntimeError: This always fails!'")
+
+    execution_error = ActiveJob.jobs.failed.last.last_execution_error
+
+    assert_equal "", execution_error.error_class
+    assert_equal "RuntimeError: This always fails!", execution_error.message
+    assert_empty execution_error.backtrace
+  end
+
   private
     def queue_adapter
       :solid_queue


### PR DESCRIPTION
## Summary
Fixes #290. When the `error` column of a `solid_queue_failed_executions` row contains invalid JSON, every Mission Control page that loads that job (failed jobs index, job detail) responds with a 500.

## Root Cause
`SolidQueue::FailedExecution` declares `serialize :error, coder: JSON`, so reading `exception_class`/`message`/`backtrace` raises `JSON::ParserError` when the stored value isn't valid JSON (e.g. truncated by a column size limit). Mission Control reads those attributes in `execution_error_from_solid_queue_job` while proxying failed jobs, and the exception propagated up to the controller.

## Solution
Rescue `JSON::ParserError` in `execution_error_from_solid_queue_job` and build the `ActiveJob::ExecutionError` from the raw column value (`error_before_type_cast`) instead, so the raw text is shown and the page renders.

## Tests
Added a regression test in `test/active_job/queue_adapters/solid_queue_test.rb` that corrupts the `error` column with invalid JSON and asserts the failed job still loads with the raw text as the message.

- Verified the test fails before the fix with `JSON::ParserError: unexpected token at 'RuntimeError: This always fails!'` — the exact failure from the issue.
- `bin/rails test test/active_job/queue_adapters/solid_queue_test.rb`: 62 runs, 0 failures.
- `bin/rails test` (full suite): 227 runs, 1315 assertions, 0 failures, 0 errors, 1 pre-existing skip.
- `rubocop` on the changed files: no offenses.

## QA
1. Fail a job under Solid Queue.
2. Corrupt its error: `SolidQueue::FailedExecution.update_all("error = 'not json'")`.
3. Visit the failed jobs page — before this change it 500s; after, the job row renders showing the raw text.

## Risks
None identified. Behavior only changes on the code path that previously raised.
