### PR TITLE
Avoid N+1 count queries when listing Solid Queue queues

### DIFF
--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -4,12 +4,14 @@ module ActiveJob::QueueAdapters::SolidQueueExt
 
   def queues
     queues = SolidQueue::Queue.all
-    pauses = SolidQueue::Pause.where(queue_name: queues.map(&:name)).index_by(&:queue_name)
+    queue_names = queues.map(&:name)
+    pauses = SolidQueue::Pause.where(queue_name: queue_names).index_by(&:queue_name)
+    sizes = SolidQueue::ReadyExecution.where(queue_name: queue_names).group(:queue_name).count
 
     queues.collect do |queue|
       {
         name: queue.name,
-        size: queue.size,
+        size: sizes[queue.name] || 0,
         active: pauses[queue.name].nil?
       }
     end

--- a/test/active_job/queue_adapters/solid_queue_test.rb
+++ b/test/active_job/queue_adapters/solid_queue_test.rb
@@ -21,9 +21,29 @@ class ActiveJob::QueueAdapters::SolidQueueTest < ActiveSupport::TestCase
     assert_empty execution_error.backtrace
   end
 
+  test "fetching queues issues a single ready executions count for all queues" do
+    create_queues "queue_1", "queue_2", "queue_3"
+
+    queries = capture_sql { ActiveJob.queues.each(&:size) }
+    ready_execution_counts = queries.count { |sql| sql.match?(/SELECT COUNT.*solid_queue_ready_executions/im) }
+
+    assert_equal 1, ready_execution_counts
+  end
+
   private
     def queue_adapter
       :solid_queue
+    end
+
+    def capture_sql
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        queries << payload[:sql] unless payload[:name] == "SCHEMA" || payload[:cached]
+      end
+      yield
+      queries
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
     end
 
     def perform_enqueued_jobs


### PR DESCRIPTION
### What

The Solid Queue adapter computes each queue's `size` with a separate `COUNT(*)` on `solid_queue_ready_executions` inside the `#queues` loop. Building the queue list therefore issues **one COUNT per queue** — an N+1 that scales with the number of queues.

It surfaces on any page that builds the queue list. For example, `JobsController#index` calls `ActiveJob.queues.map(&:name)`, which eagerly builds every queue (sizes included) just to read the names — a 6-queue install does 6 extra COUNT queries per request.

### Fix

Aggregate all sizes in a single grouped count (`group(:queue_name).count`), mirroring how pauses are already batched. The number of count queries goes from N to 1, regardless of how many queues exist.

### Testing

Added a regression test asserting a single `ready_executions` COUNT is issued when fetching queues, captured via `ActiveSupport::Notifications` (kept off `assert_queries_count`, which is Rails 7.2+, since the gem supports `>= 7.1`). Full suite green: `227 runs, 0 failures, 0 errors`.
