### PR TITLE
make turbo prefetch configurable

### DIFF
--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -7,6 +7,7 @@
 
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="turbo-cache-control" content="no-cache">
+  <meta name="turbo-prefetch" content="false">
 
   <%= stylesheet_link_tag "mission_control/jobs/bulma.min" %>
   <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>

--- a/app/views/mission_control/jobs/queues/index.html.erb
+++ b/app/views/mission_control/jobs/queues/index.html.erb
@@ -1,7 +1,6 @@
 <% navigation(title: "Queues", section: :queues)  %>
 
 <table class="queues table is-hoverable is-fullwidth">
-  <tbody>
   <thead>
   <tr>
     <th>Queue</th>
@@ -9,6 +8,8 @@
     <th></th>
   </tr>
   </thead>
+
+  <tbody>
 
   <%= render partial: "mission_control/jobs/queues/queue", collection: @queues %>
 

--- a/test/controllers/queues_controller_test.rb
+++ b/test/controllers/queues_controller_test.rb
@@ -21,4 +21,10 @@ class MissionControl::Jobs::QueuesControllerTest < ActionDispatch::IntegrationTe
     assert_select "tbody td", "default"
     assert_select "tbody td", "1"
   end
+
+  test "turbo prefetch is disabled" do
+    get mission_control_jobs.application_queues_url(@application)
+
+    assert_select %(meta[name="turbo-prefetch"][content="false"])
+  end
 end

--- a/test/controllers/queues_controller_test.rb
+++ b/test/controllers/queues_controller_test.rb
@@ -8,4 +8,17 @@ class MissionControl::Jobs::QueuesControllerTest < ActionDispatch::IntegrationTe
 
     assert_select "article.is-danger", /Queue 'missing_queue' not found/
   end
+
+  test "get queues" do
+    job = DummyJob.perform_later(42)
+
+    get mission_control_jobs.application_queues_url(@application)
+
+    assert_select "thead th", "Queue"
+    assert_select "thead th", "Pending jobs"
+
+    assert_select "tbody tr", 1
+    assert_select "tbody td", "default"
+    assert_select "tbody td", "1"
+  end
 end


### PR DESCRIPTION
Hi there! 👋

I'd like to propose that we can make the usage of [Prefetching Links on Hover](https://turbo.hotwired.dev/handbook/drive#prefetching-links-on-hover) configurable.

Right now the prefetching is always enabled because it's Turbo's default.
One may want to disable it, which was not possible (yet).

Please let me know what you think about the idea.

Thanks a lot for taking the time!
