### PR TITLE
Show pending job count in queues tab

### DIFF
--- a/app/views/mission_control/jobs/queues/index.html.erb
+++ b/app/views/mission_control/jobs/queues/index.html.erb
@@ -1,5 +1,9 @@
 <% navigation(title: "Queues", section: :queues)  %>
 
+<% if @queues.any? %>
+  <p class="has-text-grey mb-4"><%= pluralize(@queues.sum(&:size), "pending job") %> across <%= pluralize(@queues.size, "queue") %></p>
+<% end %>
+
 <table class="queues table is-hoverable is-fullwidth">
   <thead>
   <tr>

--- a/test/controllers/queues_controller_test.rb
+++ b/test/controllers/queues_controller_test.rb
@@ -14,6 +14,7 @@ class MissionControl::Jobs::QueuesControllerTest < ActionDispatch::IntegrationTe
 
     get mission_control_jobs.application_queues_url(@application)
 
+    assert_select "p", "1 pending job across 1 queue"
     assert_select "thead th", "Queue"
     assert_select "thead th", "Pending jobs"
 

--- a/test/system/list_queues_test.rb
+++ b/test/system/list_queues_test.rb
@@ -8,6 +8,8 @@ class ListQueuesTest < ApplicationSystemTestCase
   test "list queues sorted by name" do
     visit queues_path
 
+    assert_text "10 pending jobs across 10 queues"
+
     assert_equal 10, queue_row_elements.length
     queue_row_elements.each.with_index do |queue_element, index|
       within queue_element do


### PR DESCRIPTION
The Queues tab is the entry point for pending jobs, but unlike the other job status tabs it didn't show the total count.

Show the total pending job count in the tab label so the backlog is visible from the top-level navigation.