### PR TITLE
Add bulk and individual job discard functionality for queues

### DIFF
--- a/app/controllers/mission_control/jobs/queues/bulk_discards_controller.rb
+++ b/app/controllers/mission_control/jobs/queues/bulk_discards_controller.rb
@@ -1,0 +1,11 @@
+class MissionControl::Jobs::Queues::BulkDiscardsController < MissionControl::Jobs::ApplicationController
+  include MissionControl::Jobs::QueueScoped
+
+  def create
+    pending_jobs = @queue.jobs.pending
+    count = pending_jobs.count
+    pending_jobs.discard_all
+
+    redirect_back fallback_location: application_queue_url(@application, @queue.name), notice: "Discarded #{count} pending #{"job".pluralize(count)}"
+  end
+end

--- a/app/controllers/mission_control/jobs/queues/discards_controller.rb
+++ b/app/controllers/mission_control/jobs/queues/discards_controller.rb
@@ -1,0 +1,20 @@
+class MissionControl::Jobs::Queues::DiscardsController < MissionControl::Jobs::ApplicationController
+  include MissionControl::Jobs::QueueScoped
+  include MissionControl::Jobs::JobScoped
+
+  def create
+    unless @job.pending?
+      return redirect_to application_queue_url(@application, @queue.name),
+        alert: "Only pending jobs can be discarded from a queue"
+    end
+
+    @job.discard
+
+    redirect_to application_queue_url(@application, @queue.name), notice: "Discarded job with id #{@job.job_id}"
+  end
+
+  private
+    def jobs_relation
+      @queue.jobs.pending
+    end
+end

--- a/app/views/mission_control/jobs/queues/_actions.html.erb
+++ b/app/views/mission_control/jobs/queues/_actions.html.erb
@@ -1,7 +1,13 @@
 <div class="buttons is-right">
-  <% if queue.active? %>
-    <%= button_to "Pause", application_queue_pause_path(@application, queue.name), method: :post, class: "button is-success is-light mr-0" %>
-  <% else %>
-    <%= button_to "Resume", application_queue_pause_path(@application, queue.name), method: :delete, class: "button is-warning is-light mr-0" %>
+  <%= button_to "Discard all pending jobs", application_queue_bulk_discards_path(@application, queue.name),
+    method: :post, disabled: queue.size == 0, class: "button is-danger is-light",
+    form: { data: { turbo_confirm: "This will discard all pending jobs in this queue and can't be undone. Are you sure?" } } %>
+
+  <% if queue_pausing_supported? %>
+    <% if queue.active? %>
+      <%= button_to "Pause", application_queue_pause_path(@application, queue.name), method: :post, class: "button is-success is-light mr-0" %>
+    <% else %>
+      <%= button_to "Resume", application_queue_pause_path(@application, queue.name), method: :delete, class: "button is-warning is-light mr-0" %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/mission_control/jobs/queues/_job.html.erb
+++ b/app/views/mission_control/jobs/queues/_job.html.erb
@@ -12,4 +12,12 @@
       </span>
     <% end %>
   </td>
+  <td class="pr-0">
+    <% if job.pending? %>
+      <div class="buttons is-right">
+        <%= button_to "Discard", application_queue_job_discard_path(@application, @queue.name, job.job_id), class: "button is-danger is-light mr-0",
+          form: { data: { turbo_confirm: "This will delete the job and can't be undone. Are you sure?" } } %>
+      </div>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/mission_control/jobs/queues/_queue.html.erb
+++ b/app/views/mission_control/jobs/queues/_queue.html.erb
@@ -9,8 +9,6 @@
     <%= queue.size %>
   </td>
   <td class="pr-0">
-    <% if queue_pausing_supported? %>
-      <%= render "mission_control/jobs/queues/actions", queue: queue %>
-    <% end %>
+    <%= render "mission_control/jobs/queues/actions", queue: queue %>
   </td>
 </tr>

--- a/app/views/mission_control/jobs/queues/_queue_title.html.erb
+++ b/app/views/mission_control/jobs/queues/_queue_title.html.erb
@@ -6,11 +6,9 @@
         <span class="ml-4 tag is-warning">Paused</span>
       <% end %>
     </div>
-    <% if queue_pausing_supported? %>
-      <div class="level-right">
-        <%= render "mission_control/jobs/queues/actions", queue: queue %>
-      </div>
-    <% end %>
+    <div class="level-right">
+      <%= render "mission_control/jobs/queues/actions", queue: queue %>
+    </div>
   </div>
 </h1>
 

--- a/app/views/mission_control/jobs/queues/show.html.erb
+++ b/app/views/mission_control/jobs/queues/show.html.erb
@@ -11,6 +11,7 @@
     <tr>
       <th class="job-header">Job</th>
       <th></th>
+      <th></th>
     </tr>
     </thead>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@ MissionControl::Jobs::Engine.routes.draw do
     resources :queues, only: [ :index, :show ] do
       scope module: :queues do
         resource :pause, only: [ :create, :destroy ]
+        resource :bulk_discards, only: :create
+
+        resources :jobs, only: [] do
+          resource :discard, only: :create
+        end
       end
     end
 

--- a/test/controllers/queues/bulk_discards_controller_test.rb
+++ b/test/controllers/queues/bulk_discards_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class MissionControl::Jobs::Queues::BulkDiscardsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    DummyJob.queue_as :queue_1
+    3.times { |index| DummyJob.perform_later("job-#{index}") }
+  end
+
+  test "discard all pending jobs in a queue" do
+    assert_equal 3, ActiveJob.queues[:queue_1].size
+
+    post mission_control_jobs.application_queue_bulk_discards_url(@application, :queue_1)
+    assert_redirected_to mission_control_jobs.application_queue_url(@application, "queue_1")
+    assert_equal "Discarded 3 pending jobs", flash[:notice]
+    assert_nil ActiveJob.queues[:queue_1]
+  end
+
+  test "discard all pending jobs when the queue has a single job" do
+    ActiveJob.queues[:queue_1].jobs.discard_all
+    DummyJob.perform_later("only-job")
+
+    post mission_control_jobs.application_queue_bulk_discards_url(@application, :queue_1)
+    assert_redirected_to mission_control_jobs.application_queue_url(@application, "queue_1")
+    assert_equal "Discarded 1 pending job", flash[:notice]
+    assert_nil ActiveJob.queues[:queue_1]
+  end
+
+  test "discard all pending jobs when the queue does not exist" do
+    post mission_control_jobs.application_queue_bulk_discards_url(@application, :missing_queue)
+    assert_redirected_to mission_control_jobs.root_url
+    assert_equal "Queue 'missing_queue' not found", flash[:alert]
+  end
+end

--- a/test/controllers/queues/discards_controller_test.rb
+++ b/test/controllers/queues/discards_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class MissionControl::Jobs::Queues::DiscardsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    DummyJob.queue_as :queue_1
+    @kept_job = DummyJob.perform_later("kept-job")
+    @job = DummyJob.perform_later("pending-job")
+  end
+
+  test "discard a single pending job in a queue" do
+    assert_equal 2, ActiveJob.queues[:queue_1].size
+
+    post mission_control_jobs.application_queue_job_discard_url(@application, :queue_1, @job.job_id)
+    assert_redirected_to mission_control_jobs.application_queue_url(@application, "queue_1")
+    assert_equal "Discarded job with id #{@job.job_id}", flash[:notice]
+
+    remaining_jobs = ActiveJob.queues[:queue_1].jobs.to_a
+    assert_equal 1, remaining_jobs.size
+    assert_equal @kept_job.job_id, remaining_jobs.first.job_id
+  end
+
+  test "discard a pending job with an invalid id" do
+    post mission_control_jobs.application_queue_job_discard_url(@application, :queue_1, "unknown_id")
+    assert_redirected_to mission_control_jobs.application_queue_url(@application, :queue_1)
+    assert_match(/Job with id 'unknown_id' not found/, flash[:alert])
+    assert_equal 2, ActiveJob.queues[:queue_1].reload.size
+  end
+
+  test "discard a pending job when the queue does not exist" do
+    post mission_control_jobs.application_queue_job_discard_url(@application, :missing_queue, @job.job_id)
+    assert_redirected_to mission_control_jobs.root_url
+    assert_equal "Queue 'missing_queue' not found", flash[:alert]
+  end
+
+  test "does not discard finished jobs through the queue discard endpoint" do
+    ActiveJob.queues[:queue_1].jobs.discard_all
+
+    finished_job = DummyJob.perform_later("finished-job")
+    perform_enqueued_jobs_async
+
+    pending_job = DummyJob.perform_later("still-pending")
+    assert_equal 1, ActiveJob.queues[:queue_1].size
+
+    post mission_control_jobs.application_queue_job_discard_url(@application, :queue_1, finished_job.job_id)
+    assert_redirected_to mission_control_jobs.application_queue_url(@application, :queue_1)
+    assert_equal "Only pending jobs can be discarded from a queue", flash[:alert]
+    assert_equal [ pending_job.job_id ], ActiveJob.queues[:queue_1].reload.jobs.map(&:job_id)
+  end
+end

--- a/test/system/discard_queue_jobs_test.rb
+++ b/test/system/discard_queue_jobs_test.rb
@@ -1,0 +1,64 @@
+require_relative "../application_system_test_case"
+
+class DiscardQueueJobsTest < ApplicationSystemTestCase
+  setup do
+    DummyJob.queue_as :queue_1
+    10.times { |index| DummyJob.perform_later("job-#{index}") }
+
+    visit queues_path
+  end
+
+  test "discard all pending jobs in a queue from the list of queues" do
+    within_queue_row "queue_1" do
+      assert_text "10"
+
+      accept_confirm do
+        click_on "Discard all pending jobs"
+      end
+    end
+
+    assert_text "Discarded 10 pending jobs"
+
+    within_queue_row "queue_1" do
+      assert_text "0"
+      assert_button "Discard all pending jobs", disabled: true
+    end
+  end
+
+  test "discard all pending jobs in a queue from the details screen" do
+    click_on "queue_1"
+
+    assert_equal 10, job_row_elements.length
+
+    accept_confirm do
+      click_on "Discard all pending jobs"
+    end
+
+    assert_text "Discarded 10 pending jobs"
+    assert_text /queue is empty/i
+  end
+
+  test "discard all pending jobs button is disabled when the queue is empty" do
+    perform_enqueued_jobs
+    click_on "queue_1"
+
+    assert_button "Discard all pending jobs", disabled: true
+  end
+
+  test "discard a single pending job from the queue details screen" do
+    click_on "queue_1"
+
+    assert_equal 10, job_row_elements.length
+    expected_job_id = ActiveJob.queues["queue_1"].jobs.find { |job| job.serialized_arguments == [ "job-3" ] }.job_id
+
+    within_job_row("job-3") do
+      accept_confirm do
+        click_on "Discard"
+      end
+    end
+
+    assert_text "Discarded job with id #{expected_job_id}"
+    assert_equal 9, job_row_elements.length
+    assert_no_text "job-3"
+  end
+end


### PR DESCRIPTION
## Summary
- Add **Discard** for a single pending job and **Discard all pending jobs** on queue views (list + details), addressing #273.
- Scope discard to pending jobs only: UI shows the button when `job.pending?`, bulk discard uses `@queue.jobs.pending`, and the single-job endpoint rejects non-pending jobs.
- Show queue actions (including discard) independently of queue pausing support; Pause/Resume remain gated by `queue_pausing_supported?`.
## Test plan
- [ ] Open a queue with pending jobs → discard one job → it disappears and flash confirms
- [ ] Discard all pending jobs from the queue details screen → queue is empty
- [ ] Discard all from the queues index → pending count goes to 0, button becomes disabled
- [ ] Empty queue → “Discard all pending jobs” is disabled
- [ ] Confirm dialog appears before discard (single and bulk)
- [ ] Pause/Resume still work when the adapter supports pausing
- [ ] Run: `bin/rails test test/system/discard_queue_jobs_test.rb test/controllers/queues/`

## Demo

<img width="1399" height="552" alt="Screenshot 2026-07-18 at 00 23 16" src="https://github.com/user-attachments/assets/ffb61947-83d2-44a6-8587-ba9cb7798771" />
<img width="1421" height="674" alt="Screenshot 2026-07-18 at 00 23 27" src="https://github.com/user-attachments/assets/faae67b3-1a7f-4e30-8d8d-7046842b41b5" />

https://github.com/user-attachments/assets/bbc00ac4-e452-4379-87a9-f385de7bf611


