### PR TITLE
Allow customizing the "Back to main app" link path

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Besides `base_controller_class`, you can also set the following for `MissionCont
 - `show_console_help`: whether to show the console help. If you don't want the console help message, set this to `false`—defaults to `true`.
 - `backtrace_cleaner`: a backtrace cleaner used for optionally filtering backtraces on the Failed Jobs detail page. Defaults to `Rails::BacktraceCleaner.new`. See the [Advanced configuration](#advanced-configuration) section for how to configure/override this setting on a per application/server basis.
 - `filter_arguments`: an array of strings representing the job argument keys you want to filter out in the UI. This is useful for hiding sensitive user data. Currently, only root-level hash keys are supported.
+- `back_to_main_app_path`: the path used by the "Back to main app" link in the navbar. Defaults to `nil`, which falls back to the host app's `main_app.root_path`. Set it to a specific path (e.g. `"/admin"`) if you mount Mission Control Jobs under an admin namespace and want the link to go back there instead of the top-level root. Set it to `false` to hide the link entirely.
 
 This library extends Active Job with a querying interface and the following setting:
 - `config.active_job.default_page_size`: the internal batch size that Active Job will use when sending queries to the underlying adapter and the batch size for the bulk operations defined above—defaults to `1000`.

--- a/app/views/layouts/mission_control/jobs/_application_selection.html.erb
+++ b/app/views/layouts/mission_control/jobs/_application_selection.html.erb
@@ -1,8 +1,12 @@
 <nav class="navbar" role="navigation" aria-label="main navigation">
   <div class="navbar-menu is-active mb-4">
     <div class="navbar-start">
-      <% if defined?(main_app.root_path) %>
-        <%= link_to "Back to main app", main_app.root_path %>
+      <%
+        back_to_main_app_path = MissionControl::Jobs.back_to_main_app_path
+        back_to_main_app_path = main_app.root_path if back_to_main_app_path.nil? && defined?(main_app.root_path)
+      %>
+      <% if back_to_main_app_path %>
+        <%= link_to "Back to main app", back_to_main_app_path %>
       <% end %>
     </div>
 

--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -34,6 +34,8 @@ module MissionControl
 
     mattr_accessor :filter_arguments, default: []
 
+    mattr_accessor :back_to_main_app_path
+
     def self.job_arguments_filter
       MissionControl::Jobs::ArgumentsFilter.new(filter_arguments)
     end

--- a/test/controllers/navbar_test.rb
+++ b/test/controllers/navbar_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class MissionControl::Jobs::NavbarTest < ActionDispatch::IntegrationTest
+  teardown do
+    MissionControl::Jobs.back_to_main_app_path = nil
+  end
+
+  test "back to main app link defaults to main_app.root_path" do
+    get mission_control_jobs.application_queues_url(@application)
+    assert_response :ok
+
+    assert_select "a", text: "Back to main app" do |elements|
+      assert_equal "/", URI.parse(elements.first["href"]).path
+    end
+  end
+
+  test "back to main app link uses the configured path when set" do
+    MissionControl::Jobs.back_to_main_app_path = "/admin"
+
+    get mission_control_jobs.application_queues_url(@application)
+    assert_response :ok
+
+    assert_select "a[href=?]", "/admin", text: "Back to main app"
+  end
+
+  test "back to main app link is hidden when explicitly disabled" do
+    MissionControl::Jobs.back_to_main_app_path = false
+
+    get mission_control_jobs.application_queues_url(@application)
+    assert_response :ok
+
+    assert_select "a", text: "Back to main app", count: 0
+  end
+end


### PR DESCRIPTION
## Summary

fixed https://github.com/rails/mission_control-jobs/issues/326

- Adds `MissionControl::Jobs.back_to_main_app_path` so apps that mount Mission Control Jobs under an admin namespace (e.g. `/admin/jobs`) can point the "Back to main app" navbar link somewhere other than the host app's root.
- Defaults to `nil`, which preserves today's behavior of falling back to `main_app.root_path` (resolved lazily in the view, since it can't be resolved at config-load time).
- Set to a path string (e.g. `"/admin"`) to override, or `false` to hide the link entirely.

## Test plan

- [x] `bundle exec rake app:test` — 229 runs, 0 failures
- [x] `bundle exec rubocop lib/mission_control/jobs.rb test/controllers/navbar_test.rb` — no offenses
- [x] Added `test/controllers/navbar_test.rb` covering default fallback, custom path, and disabled (`false`) cases
- [x] Pass CI from forked repository.
  - https://github.com/madogiwa0124/mission_control-jobs/pull/1