### PR TITLE
Batch support for Solid Queue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,13 +248,13 @@ GEM
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     smart_properties (1.17.0)
-    solid_queue (1.0.1)
+    solid_queue (1.7.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
       concurrent-ruby (>= 1.3.1)
-      fugit (~> 1.11.0)
+      fugit (~> 1.11)
       railties (>= 7.1)
-      thor (~> 1.3.1)
+      thor (>= 1.3.1)
     sqlite3 (2.2.0-aarch64-linux-gnu)
     sqlite3 (2.2.0-arm-linux-gnu)
     sqlite3 (2.2.0-arm64-darwin)
@@ -307,7 +307,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails-omakase
   selenium-webdriver
-  solid_queue (~> 1.0.1)
+  solid_queue (~> 1.0)
   sqlite3
 
 BUNDLED WITH

--- a/app/controllers/concerns/mission_control/jobs/adapter_features.rb
+++ b/app/controllers/concerns/mission_control/jobs/adapter_features.rb
@@ -2,7 +2,7 @@ module MissionControl::Jobs::AdapterFeatures
   extend ActiveSupport::Concern
 
   included do
-    helper_method :supported_job_statuses, :queue_pausing_supported?, :workers_exposed?, :recurring_tasks_supported?
+    helper_method :supported_job_statuses, :queue_pausing_supported?, :workers_exposed?, :recurring_tasks_supported?, :batches_supported?
   end
 
   private
@@ -20,5 +20,9 @@ module MissionControl::Jobs::AdapterFeatures
 
     def recurring_tasks_supported?
       MissionControl::Jobs::Current.server.queue_adapter.supports_recurring_tasks?
+    end
+
+    def batches_supported?
+      MissionControl::Jobs::Current.server.queue_adapter.supports_batches?
     end
 end

--- a/app/controllers/concerns/mission_control/jobs/not_found_redirections.rb
+++ b/app/controllers/concerns/mission_control/jobs/not_found_redirections.rb
@@ -29,6 +29,8 @@ module MissionControl::Jobs::NotFoundRedirections
         application_recurring_tasks_path(@application)
       when /queue/i
         application_queues_path(@application)
+      when /batch/i
+        application_batches_path(@application)
       else
         root_url
       end

--- a/app/controllers/mission_control/jobs/batches_controller.rb
+++ b/app/controllers/mission_control/jobs/batches_controller.rb
@@ -1,0 +1,59 @@
+class MissionControl::Jobs::BatchesController < MissionControl::Jobs::ApplicationController
+  UNFINISHED_JOB_STATUSES = %i[ pending in_progress blocked scheduled ]
+  BATCHES_STATUSES = %w[ finished unfinished failed ]
+
+  before_action :ensure_supported_batches
+  before_action :set_batch, only: :show
+
+  def index
+    @batches_page = MissionControl::Jobs::Page.new(batches, page: params[:page].to_i)
+  end
+
+  def show
+    @jobs_page = MissionControl::Jobs::Page.new(@batch.jobs.with_status(jobs_status.to_sym), page: params[:page].to_i)
+  end
+
+  private
+    def ensure_supported_batches
+      unless batches_supported?
+        redirect_to root_url, alert: "This server doesn't support batches"
+      end
+    end
+
+    def set_batch
+      @batch = MissionControl::Jobs::Current.server.find_batch(params[:id])
+    end
+
+    def batches
+      MissionControl::Jobs::Current.server.batches(status: batches_status&.to_sym)
+    end
+
+    helper_method :batches_status, :batches_filter_param, :jobs_status
+
+    # Default to unfinished: finished/all populations can be multi-million-row,
+    # and only unfinished batches are actionable.
+    def batches_status
+      requested = params.fetch(:batches_status, "unfinished")
+      requested.presence_in(BATCHES_STATUSES) unless requested == "all"
+    end
+
+    # +batches_status+ is nil for the "all" population so the adapter query stays
+    # unfiltered, but the sentinel has to survive pagination links.
+    def batches_filter_param
+      { batches_status: batches_status || "all" }
+    end
+
+    def jobs_status
+      params[:jobs_status].presence&.to_s || default_jobs_status
+    end
+
+    def default_jobs_status
+      if @batch.failed?
+        "failed"
+      elsif @batch.finished?
+        "finished"
+      else
+        UNFINISHED_JOB_STATUSES.find { |status| @batch.public_send("#{status}_jobs") > 0 }&.to_s || "pending"
+      end
+    end
+end

--- a/app/helpers/mission_control/jobs/interface_helper.rb
+++ b/app/helpers/mission_control/jobs/interface_helper.rb
@@ -20,4 +20,17 @@ module MissionControl::Jobs::InterfaceHelper
     else "is-primary is-light"
     end
   end
+
+  def label_for_batch_job_status(status)
+    status == :finished ? "completed" : status.to_s.humanize.downcase
+  end
+
+  def modifier_for_batch_status(status)
+    case status.to_s
+    when "completed" then "is-success"
+    when "failed"    then "is-danger"
+    when "enqueued"  then "is-info"
+    else "is-light"
+    end
+  end
 end

--- a/app/helpers/mission_control/jobs/navigation_helper.rb
+++ b/app/helpers/mission_control/jobs/navigation_helper.rb
@@ -13,6 +13,7 @@ module MissionControl::Jobs::NavigationHelper
 
       sections[:workers] = [ "Workers", application_workers_path(@application) ] if workers_exposed?
       sections[:recurring_tasks] = [ "Recurring tasks", application_recurring_tasks_path(@application) ] if recurring_tasks_supported?
+      sections[:batches] = [ "Batches", application_batches_path(@application) ] if batches_supported?
     end
   end
 

--- a/app/models/mission_control/jobs/batch.rb
+++ b/app/models/mission_control/jobs/batch.rb
@@ -1,0 +1,38 @@
+class MissionControl::Jobs::Batch
+  include ActiveModel::Model
+
+  attr_accessor :id, :description, :status, :total_jobs, :completed_jobs, :failed_jobs,
+    :pending_jobs, :in_progress_jobs, :blocked_jobs, :scheduled_jobs, :progress_percentage,
+    :metadata, :enqueued_at, :finished_at
+
+  def initialize(queue_adapter: ActiveJob::Base.queue_adapter, **kwargs)
+    @queue_adapter = queue_adapter
+    super(**kwargs)
+  end
+
+  def jobs
+    ActiveJob::JobsRelation.new(queue_adapter: queue_adapter).where(batch_id: id)
+  end
+
+  def job_counts
+    {
+      finished: completed_jobs,
+      failed: failed_jobs,
+      pending: pending_jobs,
+      in_progress: in_progress_jobs,
+      blocked: blocked_jobs,
+      scheduled: scheduled_jobs
+    }
+  end
+
+  def finished?
+    finished_at.present?
+  end
+
+  def failed?
+    status == :failed
+  end
+
+  private
+    attr_reader :queue_adapter
+end

--- a/app/models/mission_control/jobs/page.rb
+++ b/app/models/mission_control/jobs/page.rb
@@ -1,7 +1,7 @@
 class MissionControl::Jobs::Page
   DEFAULT_PAGE_SIZE = 10
 
-  attr_reader :records, :index, :page_size
+  attr_reader :index, :page_size
 
   def initialize(relation, page: 1, page_size: DEFAULT_PAGE_SIZE)
     @relation = relation
@@ -9,8 +9,11 @@ class MissionControl::Jobs::Page
     @index = [ page, 1 ].max
   end
 
+  # Materialized once: rendering the collection and the pagination toolbar's
+  # predicates all ask for this page, and a fresh relation would re-run the
+  # (potentially capped and expensive) count query on each of them.
   def records
-    @relation.limit(page_size).offset(offset)
+    @records ||= @relation.limit(page_size).offset(offset).to_a
   end
 
   def first?

--- a/app/views/mission_control/jobs/batches/_batch.html.erb
+++ b/app/views/mission_control/jobs/batches/_batch.html.erb
@@ -1,0 +1,21 @@
+<tr class="batch">
+  <td>
+    <%= link_to batch.id, application_batch_path(@application, batch.id) %>
+  </td>
+  <td>
+    <% if batch.description.present? %>
+      <%= batch.description %>
+    <% else %>
+      <span class="has-text-grey">No description</span>
+    <% end %>
+  </td>
+  <td><%= render "mission_control/jobs/batches/status", batch: batch %></td>
+  <td><%= number_to_percentage batch.progress_percentage, precision: 0 %></td>
+  <td>
+    <%= batch.total_jobs %>
+    <% if batch.failed_jobs > 0 %>
+      <span class="has-text-danger">(<%= batch.failed_jobs %> failed)</span>
+    <% end %>
+  </td>
+  <td><div class="has-text-grey"><%= batch.enqueued_at ? bidirectional_time_distance_in_words_with_title(batch.enqueued_at) : "Not started" %></div></td>
+</tr>

--- a/app/views/mission_control/jobs/batches/_general_information.html.erb
+++ b/app/views/mission_control/jobs/batches/_general_information.html.erb
@@ -1,0 +1,36 @@
+<table class="table">
+  <tbody>
+  <tr>
+    <th>Progress</th>
+    <td>
+      <progress class="progress <%= batch.failed? ? "is-danger" : "is-success" %>" value="<%= batch.progress_percentage %>" max="100"><%= number_to_percentage batch.progress_percentage, precision: 0 %></progress>
+      <% job_counts = batch.job_counts %>
+      <% job_counts.each.with_index do |(status, count), index| %>
+        <% if count > 0 %>
+          <%= link_to "#{count} #{label_for_batch_job_status(status)}", application_batch_path(@application, batch.id, jobs_status: status), class: ("has-text-danger" if status == :failed) %>
+        <% else %>
+          <%= count %> <%= label_for_batch_job_status(status) %>
+        <% end %>
+        <%= "," unless index == job_counts.size - 1 %>
+      <% end %>
+      of <%= batch.total_jobs %> total
+    </td>
+  </tr>
+  <tr>
+    <th>Enqueued</th>
+    <td><%= batch.enqueued_at ? bidirectional_time_distance_in_words_with_title(batch.enqueued_at) : "Not started" %></td>
+  </tr>
+  <% if batch.finished_at.present? %>
+    <tr>
+      <th>Finished</th>
+      <td><%= bidirectional_time_distance_in_words_with_title(batch.finished_at) %></td>
+    </tr>
+  <% end %>
+  <% if batch.metadata.present? %>
+    <tr>
+      <th>Metadata</th>
+      <td><div class="is-family-monospace"><%= batch.metadata %></div></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/mission_control/jobs/batches/_status.html.erb
+++ b/app/views/mission_control/jobs/batches/_status.html.erb
@@ -1,0 +1,1 @@
+<span class="tag <%= modifier_for_batch_status(batch.status) %>"><%= batch.status %></span>

--- a/app/views/mission_control/jobs/batches/_title.html.erb
+++ b/app/views/mission_control/jobs/batches/_title.html.erb
@@ -1,0 +1,13 @@
+<h1 class="title">
+  <div class="level">
+    <div class="level-left">
+      Batch <%= batch.id %>
+      <% if batch.description.present? %>
+        <span class="has-text-grey ml-2"><%= batch.description %></span>
+      <% end %>
+    </div>
+    <div class="level-right">
+      <%= render "mission_control/jobs/batches/status", batch: batch %>
+    </div>
+  </div>
+</h1>

--- a/app/views/mission_control/jobs/batches/index.html.erb
+++ b/app/views/mission_control/jobs/batches/index.html.erb
@@ -1,0 +1,37 @@
+<% navigation(title: "Batches", section: :batches)  %>
+
+<% if @batches_page.empty? && batches_status.nil? %>
+  <%= blank_status_notice "There are no batches" %>
+<% else %>
+  <div class="tabs">
+    <ul>
+      <li class="<%= "is-active" if batches_status.nil? %>"><%= link_to "All", application_batches_path(@application, batches_status: "all") %></li>
+      <li class="<%= "is-active" if batches_status == "unfinished" %>"><%= link_to "Unfinished", application_batches_path(@application, batches_status: "unfinished") %></li>
+      <li class="<%= "is-active" if batches_status == "finished" %>"><%= link_to "Finished", application_batches_path(@application, batches_status: "finished") %></li>
+      <li class="<%= "is-active" if batches_status == "failed" %>"><%= link_to "Failed", application_batches_path(@application, batches_status: "failed") %></li>
+    </ul>
+  </div>
+
+  <% if @batches_page.empty? %>
+    <%= blank_status_notice "No #{batches_status} batches found" %>
+  <% else %>
+    <table class="batches table jobs is-hoverable is-fullwidth">
+      <thead>
+      <tr>
+        <th></th>
+        <th>Description</th>
+        <th>Status</th>
+        <th>Progress</th>
+        <th>Jobs</th>
+        <th>Enqueued</th>
+      </tr>
+      </thead>
+
+      <tbody>
+        <%= render partial: "mission_control/jobs/batches/batch", collection: @batches_page.records %>
+      </tbody>
+    </table>
+
+    <%= render "mission_control/jobs/shared/pagination_toolbar", page: @batches_page, filter_param: batches_filter_param %>
+  <% end %>
+<% end %>

--- a/app/views/mission_control/jobs/batches/show.html.erb
+++ b/app/views/mission_control/jobs/batches/show.html.erb
@@ -1,0 +1,18 @@
+<% navigation(title: "Batch #{@batch.id}", section: :batches) %>
+
+<%= render "mission_control/jobs/batches/title", batch: @batch %>
+<%= render "mission_control/jobs/batches/general_information", batch: @batch %>
+
+<% if @jobs_page.empty? %>
+  <%= blank_status_notice "No #{jobs_status.dasherize} jobs found for this batch" %>
+<% else %>
+  <h2 class="subtitle"><%= pluralize @jobs_page.total_count, "#{jobs_status.dasherize} job" %></h2>
+
+  <% if jobs_status == "pending" %>
+    <%= render "mission_control/jobs/shared/jobs", jobs: @jobs_page.records %>
+  <% else %>
+    <%= render "mission_control/jobs/jobs/jobs_page", jobs_page: @jobs_page %>
+  <% end %>
+
+  <%= render "mission_control/jobs/shared/pagination_toolbar", page: @jobs_page, filter_param: jobs_filter_param.merge(jobs_status: jobs_status) %>
+<% end %>

--- a/app/views/mission_control/jobs/jobs/_general_information.html.erb
+++ b/app/views/mission_control/jobs/jobs/_general_information.html.erb
@@ -73,5 +73,13 @@
       </td>
     </tr>
   <% end %>
+  <% if job.batch_id.present? %>
+    <tr>
+      <th>Part of</th>
+      <td>
+        <%= link_to "batch #{job.batch_id}", application_batch_path(@application, job.batch_id) %>
+      </td>
+    </tr>
+  <% end %>
   </tbody>
 </table>

--- a/app/views/mission_control/jobs/shared/_pagination_toolbar.html.erb
+++ b/app/views/mission_control/jobs/shared/_pagination_toolbar.html.erb
@@ -3,5 +3,7 @@
   <%= link_to "↞", url_for(page: 1, **filter_param), class: "pagination-previous", disabled: page.first? %>
   <%= link_to "Previous page", url_for(page: page.previous_index, **filter_param), class: "pagination-previous", disabled: page.first? %>
   <%= link_to "Next page", url_for(page: page.next_index, **filter_param), class: "pagination-next", disabled: page.last? %>
-  <%= link_to "↠", url_for(page: page.pages_count, **filter_param), class: "pagination-next", disabled: page.last? %>
+  <% if page.pages_count %><%# With more records than internal_query_count_limit, the count is capped and the last page is unknown %>
+    <%= link_to "↠", url_for(page: page.pages_count, **filter_param), class: "pagination-next", disabled: page.last? %>
+  <% end %>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ MissionControl::Jobs::Engine.routes.draw do
 
     resources :workers, only: [ :index, :show ]
     resources :recurring_tasks, only: [ :index, :show, :update ]
+    resources :batches, only: [ :index, :show ]
   end
 
   # Allow referencing urls without providing an application_id. It will default to the first one.

--- a/lib/active_job/job_proxy.rb
+++ b/lib/active_job/job_proxy.rb
@@ -9,6 +9,9 @@ class ActiveJob::JobProxy < ActiveJob::Base
   attr_reader :job_class_name
   # Raw data with the sensitive user data filtered out.
   attr_accessor :filtered_raw_data
+  # Defined here rather than on ActiveJob::Base so it can't clash with
+  # adapters that put their own batch_id on jobs, like Solid Queue.
+  attr_accessor :batch_id
 
   def initialize(job_data)
     super

--- a/lib/active_job/jobs_relation.rb
+++ b/lib/active_job/jobs_relation.rb
@@ -25,7 +25,7 @@ class ActiveJob::JobsRelation
   STATUSES = %i[ pending failed in_progress blocked scheduled finished ]
   FILTERS = %i[ queue_name job_class_name scheduled_at enqueued_at ]
 
-  PROPERTIES = %i[ queue_name status offset_value limit_value job_class_name worker_id recurring_task_id finished_at scheduled_at enqueued_at ]
+  PROPERTIES = %i[ queue_name status offset_value limit_value job_class_name worker_id recurring_task_id batch_id finished_at scheduled_at enqueued_at ]
   attr_reader(*PROPERTIES, :default_page_size)
 
   delegate :last, :[], :reverse, to: :to_a
@@ -51,15 +51,17 @@ class ActiveJob::JobsRelation
   # * <tt>:queue_name</tt> - To only include the jobs in the provided queue.
   # * <tt>:worker_id</tt> - To only include the jobs processed by the provided worker.
   # * <tt>:recurring_task_id</tt> - To only include the jobs corresponding to runs of a recurring task.
+  # * <tt>:batch_id</tt> - To only include the jobs belonging to a given batch.
   # * <tt>:finished_at</tt> - (Range) To only include the jobs finished between the provided range
   # * <tt>:scheduled_at</tt> - (Range) To only include the jobs scheduled between the provided range
   # * <tt>:enqueued_at</tt> - (Range) To only include the jobs enqueued between the provided range
-  def where(job_class_name: nil, queue_name: nil, worker_id: nil, recurring_task_id: nil, finished_at: nil, scheduled_at: nil, enqueued_at: nil)
+  def where(job_class_name: nil, queue_name: nil, worker_id: nil, recurring_task_id: nil, batch_id: nil, finished_at: nil, scheduled_at: nil, enqueued_at: nil)
     # Remove nil arguments to avoid overriding parameters when concatenating +where+ clauses
     arguments = { job_class_name: job_class_name,
       queue_name: queue_name&.to_s,
       worker_id: worker_id,
       recurring_task_id: recurring_task_id,
+      batch_id: batch_id,
       finished_at: finished_at,
       scheduled_at: scheduled_at,
       enqueued_at: enqueued_at

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -1,6 +1,6 @@
 module ActiveJob::QueueAdapters::SolidQueueExt
   include MissionControl::Jobs::Adapter
-  include RecurringTasks, Workers
+  include RecurringTasks, Workers, Batches
 
   def queues
     queues = SolidQueue::Queue.all
@@ -75,8 +75,8 @@ module ActiveJob::QueueAdapters::SolidQueueExt
     dispatch_immediately find_solid_queue_job!(job.job_id, jobs_relation)
   end
 
-  def find_job(job_id, *)
-    if job = SolidQueue::Job.where(active_job_id: job_id).order(:id).last
+  def find_job(job_id, jobs_relation)
+    if job = find_solid_queue_job(job_id, jobs_relation)
       deserialize_and_proxy_solid_queue_job job
     end
   end
@@ -109,6 +109,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
         job.worker_id = solid_queue_job&.claimed_execution&.process_id if job_status == :in_progress
         job.started_at = solid_queue_job&.claimed_execution&.created_at if job_status == :in_progress
         job.scheduled_at = solid_queue_job.scheduled_at
+        job.batch_id = solid_queue_job.try(:batch_id)
       end
     end
 
@@ -187,7 +188,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
         attr_reader :jobs_relation
 
         delegate :queue_name, :limit_value, :limit_value_provided?, :offset_value, :job_class_name,
-          :default_page_size, :worker_id, :recurring_task_id, :finished_at, :scheduled_at, :enqueued_at, to: :jobs_relation
+          :default_page_size, :worker_id, :recurring_task_id, :batch_id, :finished_at, :scheduled_at, :enqueued_at, to: :jobs_relation
 
         def executions
           execution_class_by_status
@@ -196,6 +197,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
             .then { |executions| filter_executions_by_class(executions) }
             .then { |executions| filter_executions_by_process_id(executions) }
             .then { |executions| filter_executions_by_task_key(executions) }
+            .then { |executions| filter_executions_by_batch(executions) }
             .then { |executions| filter_executions_by_scheduled_at(executions) }
             .then { |executions| filter_executions_by_enqueued_at(executions) }
             .then { |executions| limit(executions) }
@@ -206,6 +208,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
           SolidQueue::Job.finished
             .then { |jobs| filter_jobs_by_queue(jobs) }
             .then { |jobs| filter_jobs_by_class(jobs) }
+            .then { |jobs| filter_jobs_by_batch(jobs) }
             .then { |jobs| filter_jobs_by_finished_at(jobs) }
             .then { |jobs| filter_jobs_by_scheduled_at(jobs) }
             .then { |jobs| filter_jobs_by_enqueued_at(jobs) }
@@ -228,7 +231,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
         end
 
         def matches_relation_filters?(job)
-          matches_status?(job) && matches_queue_name?(job)
+          matches_status?(job) && matches_queue_name?(job) && matches_batch?(job)
         end
 
         def direct_count
@@ -287,6 +290,14 @@ module ActiveJob::QueueAdapters::SolidQueueExt
           recurring_task_id.present? ? executions.where(task_key: recurring_task_id) : executions
         end
 
+        def filter_executions_by_batch(executions)
+          batch_id.present? ? executions.where(job: { batch_id: batch_id }) : executions
+        end
+
+        def filter_jobs_by_batch(jobs)
+          batch_id.present? ? jobs.where(batch_id: batch_id) : jobs
+        end
+
         def filter_jobs_by_class(jobs)
           job_class_name.present? ? jobs.where(class_name: job_class_name) : jobs
         end
@@ -332,6 +343,10 @@ module ActiveJob::QueueAdapters::SolidQueueExt
 
         def matches_queue_name?(job)
           queue_name.blank? || job.queue_name == queue_name
+        end
+
+        def matches_batch?(job)
+          batch_id.blank? || job.batch_id.to_s == batch_id.to_s
         end
 
         def solid_queue_status

--- a/lib/active_job/queue_adapters/solid_queue_ext/batches.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext/batches.rb
@@ -1,0 +1,116 @@
+module ActiveJob::QueueAdapters::SolidQueueExt::Batches
+  # Batches shipped in Solid Queue 1.7 as an optional migration, so the
+  # constant existing doesn't mean the tables do.
+  def supports_batches?
+    SolidQueue.const_defined?(:Batch, false) && SolidQueue::Batch.migrated?
+  end
+
+  def fetch_batches(batches_relation)
+    batches = batches_scope(batches_relation.status).order(id: :desc)
+      .offset(batches_relation.offset_value).limit(batches_relation.limit_value).to_a
+
+    # Progress comes from the tracking rows, which are always counted, so the
+    # listing only counts failures on top. The batch page needs the rest.
+    attributes_for_batches(batches, job_statuses_to_count: [ :failed ])
+  end
+
+  def count_batches(batches_relation)
+    count_limit = MissionControl::Jobs.internal_query_count_limit + 1
+    limited_count = batches_scope(batches_relation.status).limit(count_limit).count
+    (limited_count == count_limit) ? Float::INFINITY : limited_count
+  end
+
+  def find_batch(batch_id)
+    if batch = SolidQueue::Batch.find_by(id: batch_id)
+      attributes_for_batches([ batch ], job_statuses_to_count: job_execution_classes.keys).first
+    end
+  end
+
+  private
+    def batches_scope(status)
+      case status
+      when :finished   then SolidQueue::Batch.finished
+      when :unfinished then SolidQueue::Batch.unfinished
+      when :failed     then SolidQueue::Batch.failed
+      else SolidQueue::Batch.all
+      end
+    end
+
+    # Finished batches froze their counters on the row at finalize time, so
+    # only live batches pay for job counting — a page of history runs no
+    # count queries at all.
+    def attributes_for_batches(batches, job_statuses_to_count:)
+      counts_by_status = job_counts_for(batches.reject(&:finished_at?), job_statuses_to_count)
+
+      batches.collect do |batch|
+        job_counts = counts_by_status.transform_values { |counts_by_batch_id| counts_by_batch_id.fetch(batch.id, 0) }
+        batch_attributes_from_solid_queue_batch(batch, job_counts)
+      end
+    end
+
+    # One grouped count per status covers every batch given, so a page costs the
+    # same number of queries as a single batch:
+    #
+    #   { failed: { 12 => 1 }, outstanding: { 12 => 4, 13 => 9 } }
+    def job_counts_for(batches, job_statuses_to_count)
+      return {} if batches.none?
+
+      batch_ids = batches.map(&:id)
+      jobs_in_batches = SolidQueue::Job.where(batch_id: batch_ids).group(:batch_id)
+
+      counts_by_status = job_execution_classes.slice(*job_statuses_to_count).transform_values do |execution_class|
+        execution_class.joins(:job).merge(jobs_in_batches).count
+      end
+
+      counts_by_status.merge(outstanding: SolidQueue::BatchExecution.where(batch_id: batch_ids).group(:batch_id).count)
+    end
+
+    def batch_attributes_from_solid_queue_batch(batch, job_counts)
+      if batch.finished_at.present?
+        # Raw column reads: the gem's counter methods compute with live COUNT
+        # queries, and finalizing the batch already froze these on the row.
+        completed_jobs = batch[:completed_jobs]
+        job_counts = { pending: 0, in_progress: 0, blocked: 0, scheduled: 0, failed: batch[:failed_jobs] }
+        outstanding_jobs = 0
+      else
+        # +total_jobs+ counts logical jobs while the tracking rows count attempts, so a
+        # retry overlapping its previous attempt can outnumber them. Clamp like
+        # +SolidQueue::Batch::Status+ does.
+        outstanding_jobs = job_counts[:outstanding]
+        completed_jobs = [ batch.total_jobs - outstanding_jobs - job_counts[:failed], 0 ].max
+      end
+
+      {
+        id: batch.id,
+        description: batch.description,
+        status: batch.status,
+        total_jobs: batch.total_jobs,
+        completed_jobs: completed_jobs,
+        failed_jobs: job_counts[:failed],
+        pending_jobs: job_counts[:pending],
+        in_progress_jobs: job_counts[:in_progress],
+        blocked_jobs: job_counts[:blocked],
+        scheduled_jobs: job_counts[:scheduled],
+        progress_percentage: progress_percentage(batch.total_jobs, outstanding_jobs),
+        metadata: batch.metadata,
+        enqueued_at: batch.enqueued_at,
+        finished_at: batch.finished_at
+      }
+    end
+
+    def progress_percentage(total_jobs, outstanding_jobs)
+      return 0 if total_jobs == 0
+
+      ([ total_jobs - outstanding_jobs, 0 ].max * 100.0 / total_jobs).round(2)
+    end
+
+    def job_execution_classes
+      {
+        pending: SolidQueue::ReadyExecution,
+        failed: SolidQueue::FailedExecution,
+        in_progress: SolidQueue::ClaimedExecution,
+        blocked: SolidQueue::BlockedExecution,
+        scheduled: SolidQueue::ScheduledExecution
+      }
+    end
+end

--- a/lib/mission_control/jobs/adapter.rb
+++ b/lib/mission_control/jobs/adapter.rb
@@ -80,6 +80,55 @@ module MissionControl::Jobs::Adapter
   end
 
 
+  def supports_batches?
+    false
+  end
+
+  # Returns an array with the requested page of batches, newest first, honoring
+  # the relation's +offset_value+ and +limit_value+. The relation's +status+
+  # narrows the list to +:finished+, +:unfinished+ or +:failed+ batches when
+  # present. Each batch is represented as a hash with these attributes:
+  #   {
+  #     id: 123,
+  #     description: "Nightly imports",
+  #     status: :enqueued,
+  #     total_jobs: 100,
+  #     completed_jobs: 60,
+  #     failed_jobs: 2,
+  #     pending_jobs: 20,
+  #     in_progress_jobs: 10,
+  #     blocked_jobs: 5,
+  #     scheduled_jobs: 3,
+  #     progress_percentage: 62.0,
+  #     metadata: { user_id: 123 },
+  #     enqueued_at: Fri, 26 Jan 2024 20:31:09.652174000 UTC +00:00,
+  #     finished_at: nil
+  #   }
+  #
+  # The listing renders progress and failures only, so adapters may leave the
+  # +pending_jobs+, +in_progress_jobs+, +blocked_jobs+ and +scheduled_jobs+
+  # breakdown to +find_batch+ rather than counting it for every batch listed.
+  def fetch_batches(batches_relation)
+    if supports_batches?
+      raise_incompatible_adapter_error_from :fetch_batches
+    end
+  end
+
+  # Returns the total number of batches, narrowed by the relation's +status+
+  def count_batches(batches_relation)
+    if supports_batches?
+      raise_incompatible_adapter_error_from :count_batches
+    end
+  end
+
+  # Returns a batch represented by a hash as indicated above
+  def find_batch(batch_id)
+    if supports_batches?
+      raise_incompatible_adapter_error_from :find_batch
+    end
+  end
+
+
   # Returns an array with the list of queues. Each queue is represented as a hash
   # with these attributes:
   #   {

--- a/lib/mission_control/jobs/batches_relation.rb
+++ b/lib/mission_control/jobs/batches_relation.rb
@@ -1,0 +1,97 @@
+# A relation of batches.
+#
+# Relations are enumerable, so you can use +Enumerable+ methods on them.
+# Notice however that using these methods will imply loading all the relation
+# in memory, which could introduce performance concerns.
+class MissionControl::Jobs::BatchesRelation
+  include Enumerable
+
+  attr_reader :status
+  attr_accessor :offset_value, :limit_value
+
+  delegate :last, :[], :to_s, :reverse, to: :to_a
+
+  ALL_BATCHES_LIMIT = 100_000_000 # When no limit value it defaults to "all batches"
+
+  def initialize(queue_adapter:, status: nil)
+    @queue_adapter = queue_adapter
+    @status = status
+
+    set_defaults
+  end
+
+  def offset(offset)
+    clone_with offset_value: offset
+  end
+
+  def limit(limit)
+    clone_with limit_value: limit
+  end
+
+  def each(&block)
+    batches.each(&block)
+  end
+
+  def reload
+    @count = @batches = nil
+    self
+  end
+
+  def count
+    if loaded?
+      to_a.length
+    else
+      query_count
+    end
+  end
+
+  def empty?
+    count == 0
+  end
+
+  alias length count
+  alias size count
+
+  private
+    def set_defaults
+      self.offset_value = 0
+      self.limit_value = ALL_BATCHES_LIMIT
+    end
+
+    def batches
+      @batches ||= @queue_adapter.fetch_batches(self).collect do |attributes|
+        MissionControl::Jobs::Batch.new(queue_adapter: @queue_adapter, **attributes)
+      end
+    end
+
+    # How many batches a fetch would return. The adapter only counts the full
+    # set for a status, so the offset/limit window is applied arithmetically:
+    # given 100 batches, offset(30).limit(50) counts 50, and offset(90)
+    # counts 10.
+    #
+    # Given too many batches to count, +count_batches+ returns
+    # +Float::INFINITY+, which passes through the arithmetic untouched and
+    # tells +Page+ there are too many pages to link to the last one.
+    def query_count
+      @count ||= begin
+        count = [ @queue_adapter.count_batches(self) - offset_value, 0 ].max
+        limit_value_provided? ? [ count, limit_value ].min : count
+      end
+    end
+
+    def limit_value_provided?
+      limit_value.present? && limit_value != ALL_BATCHES_LIMIT
+    end
+
+    def loaded?
+      !@batches.nil?
+    end
+
+    def clone_with(**properties)
+      dup.reload.tap do |relation|
+        properties.each do |key, value|
+          relation.send("#{key}=", value)
+        end
+      end
+    end
+end

--- a/lib/mission_control/jobs/server.rb
+++ b/lib/mission_control/jobs/server.rb
@@ -2,7 +2,7 @@ require "active_job/queue_adapter"
 
 class MissionControl::Jobs::Server
   include MissionControl::Jobs::IdentifiedByName
-  include Serializable, RecurringTasks, Workers
+  include Serializable, RecurringTasks, Workers, Batches
 
   attr_reader :name, :queue_adapter, :application, :backtrace_cleaner
 

--- a/lib/mission_control/jobs/server/batches.rb
+++ b/lib/mission_control/jobs/server/batches.rb
@@ -1,0 +1,13 @@
+module MissionControl::Jobs::Server::Batches
+  def batches(status: nil)
+    MissionControl::Jobs::BatchesRelation.new(queue_adapter: queue_adapter, status: status)
+  end
+
+  def find_batch(batch_id)
+    if batch = queue_adapter.find_batch(batch_id)
+      MissionControl::Jobs::Batch.new(queue_adapter: queue_adapter, **batch)
+    else
+      raise MissionControl::Jobs::Errors::ResourceNotFound, "Batch with id '#{batch_id}' not found"
+    end
+  end
+end

--- a/mission_control-jobs.gemspec
+++ b/mission_control-jobs.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "irb", "~> 1.13"
 
   spec.add_development_dependency "resque"
-  spec.add_development_dependency "solid_queue", "~> 1.0.1"
+  spec.add_development_dependency "solid_queue", "~> 1.0"
   spec.add_development_dependency "selenium-webdriver"
   spec.add_development_dependency "resque-pause"
   spec.add_development_dependency "mocha"

--- a/test/active_job/queue_adapters/adapter_testing/find_jobs.rb
+++ b/test/active_job/queue_adapters/adapter_testing/find_jobs.rb
@@ -19,6 +19,14 @@ module ActiveJob::QueueAdapters::AdapterTesting::FindJobs
     assert_nil ActiveJob.jobs.failed.find_by_id("1234-6789")
   end
 
+  test "find returns nil when the job is outside the relation" do
+    DummyJob.queue_as(:queue_1)
+    job = DummyJob.perform_later(1234)
+
+    assert_nil ActiveJob.jobs.failed.find_by_id(job.job_id)
+    assert_nil ActiveJob.jobs.where(queue_name: :queue_2).find_by_id(job.job_id)
+  end
+
   test "find! raises an error when the job is missing" do
     assert_raises ActiveJob::Errors::JobNotFoundError do
       ActiveJob.jobs.failed.find_by_id!("1234-6789")

--- a/test/active_job/queue_adapters/solid_queue_test.rb
+++ b/test/active_job/queue_adapters/solid_queue_test.rb
@@ -50,7 +50,124 @@ class ActiveJob::QueueAdapters::SolidQueueTest < ActiveSupport::TestCase
     assert_empty ActiveJob.jobs.finished.where(scheduled_at: 1.hour.from_now..)
   end
 
+  test "supports batches only when the Solid Queue batch API is available" do
+    assert ActiveJob::Base.queue_adapter.supports_batches?
+
+    SolidQueue.stubs(:const_defined?).returns(false)
+
+    assert_not ActiveJob::Base.queue_adapter.supports_batches?
+  end
+
+  test "supports batches only when the Solid Queue batch migration has been run" do
+    SolidQueue::Batch.stubs(:migrated?).returns(false)
+
+    assert_not ActiveJob::Base.queue_adapter.supports_batches?
+  end
+
+  test "find a job by id applies the batch filter" do
+    batch_1, job_1 = create_batch
+    _batch_2, job_2 = create_batch
+
+    batch_jobs = ActiveJob.jobs.where(batch_id: batch_1.id)
+
+    assert_equal job_1.job_id, batch_jobs.find_by_id(job_1.job_id).job_id
+    assert_nil batch_jobs.find_by_id(job_2.job_id)
+  end
+
+  test "counts the jobs of every batch listed with the same three queries" do
+    4.times { create_batch }
+
+    queries = capture_select_queries do
+      batches = ActiveJob::Base.queue_adapter.fetch_batches(batches_relation)
+      assert_equal [ 0, 0, 0, 0 ], batches.pluck(:failed_jobs)
+      assert_equal [ 0.0, 0.0, 0.0, 0.0 ], batches.pluck(:progress_percentage)
+    end
+
+    assert_equal 3, queries.size, queries.join("\n\n")
+  end
+
+  test "breaks jobs down by status for a single batch" do
+    batch, = create_batch
+
+    attributes = ActiveJob::Base.queue_adapter.find_batch(batch.id)
+
+    assert_equal 1, attributes[:pending_jobs]
+    assert_equal [ 0, 0, 0, 0 ], attributes.values_at(:failed_jobs, :in_progress_jobs, :blocked_jobs, :scheduled_jobs)
+  end
+
+  test "lists finished batches without counting their jobs" do
+    batch, = create_batch
+    batch.update!(finished_at: Time.current, completed_jobs: 1, failed_jobs: 0)
+
+    queries = capture_select_queries do
+      batches = ActiveJob::Base.queue_adapter.fetch_batches(batches_relation(status: :finished))
+      assert_equal [ batch.id ], batches.pluck(:id)
+      assert_equal [ 1 ], batches.pluck(:completed_jobs)
+      assert_equal [ 100.0 ], batches.pluck(:progress_percentage)
+    end
+
+    assert_equal 1, queries.size, queries.join("\n\n")
+    assert_no_match(/solid_queue_batch_executions|solid_queue_ready_executions|solid_queue_failed_executions/, queries.first)
+  end
+
+  test "never reports negative counts while a retry overlaps its previous attempt" do
+    batch, job = create_batch
+    previous_attempt = SolidQueue::Job.find_by(active_job_id: job.job_id)
+    enqueue_retry_of previous_attempt
+
+    assert_equal 1, batch.reload.total_jobs
+    assert_equal 2, SolidQueue::BatchExecution.where(batch_id: batch.id).count
+
+    attributes = ActiveJob::Base.queue_adapter.fetch_batches(batches_relation(status: :unfinished)).sole
+
+    assert_equal 0, attributes[:completed_jobs]
+    assert_equal 0.0, attributes[:progress_percentage]
+    assert_includes 0..100, attributes[:progress_percentage]
+  end
+
+  test "caps batches count like job counts" do
+    3.times { create_batch }
+
+    original_limit = MissionControl::Jobs.internal_query_count_limit
+    MissionControl::Jobs.internal_query_count_limit = 2
+
+    assert_equal Float::INFINITY, ActiveJob::Base.queue_adapter.count_batches(batches_relation)
+    assert_equal Float::INFINITY, ActiveJob::Base.queue_adapter.count_batches(batches_relation(status: :unfinished))
+  ensure
+    MissionControl::Jobs.internal_query_count_limit = original_limit
+  end
+
+  test "returns an exact batches count below the internal limit" do
+    2.times { create_batch }
+    finished, = create_batch
+    finished.update!(finished_at: Time.current)
+
+    original_limit = MissionControl::Jobs.internal_query_count_limit
+    MissionControl::Jobs.internal_query_count_limit = 5
+
+    assert_equal 3, ActiveJob::Base.queue_adapter.count_batches(batches_relation)
+    assert_equal 2, ActiveJob::Base.queue_adapter.count_batches(batches_relation(status: :unfinished))
+    assert_equal 1, ActiveJob::Base.queue_adapter.count_batches(batches_relation(status: :finished))
+  ensure
+    MissionControl::Jobs.internal_query_count_limit = original_limit
+  end
+
   private
+    def batches_relation(status: nil)
+      MissionControl::Jobs::BatchesRelation.new(queue_adapter: ActiveJob::Base.queue_adapter, status: status)
+    end
+
+    def create_batch
+      job = nil
+      batch = SolidQueue::Batch.enqueue { job = DummyJob.perform_later }
+      [ batch, job ]
+    end
+
+    def enqueue_retry_of(job)
+      attributes = job.attributes.except("id", "created_at", "updated_at")
+      SolidQueue::Job.create!(attributes.merge("arguments" => job.arguments.merge("executions" => 1)))
+    end
+
     def queue_adapter
       :solid_queue
     end

--- a/test/controllers/batches_controller_test.rb
+++ b/test/controllers/batches_controller_test.rb
@@ -1,0 +1,401 @@
+require "test_helper"
+
+class MissionControl::Jobs::BatchesControllerTest < ActionDispatch::IntegrationTest
+  # Pinning a shared job class to an adapter would stop it inheriting the one
+  # the adapter tests set, so batches get their own job class
+  class BatchedJob < ActiveJob::Base
+    self.queue_adapter = :solid_queue
+    queue_as :default
+
+    def perform(*); end
+  end
+
+  test "get batch list" do
+    create_batch(description: "Older imports")
+    create_batch(description: "Nightly imports")
+
+    get mission_control_jobs.application_batches_url(@application)
+    assert_response :ok
+
+    assert_select "tr.batch", 2
+    assert_select "span.tag", "enqueued"
+    assert_select "li.is-active a", "Unfinished"
+    assert_equal [ "Nightly imports", "Older imports" ], css_select("tr.batch td:nth-child(2)").collect { |cell| cell.text.strip }
+  end
+
+  test "get batch list when the server doesn't support batches" do
+    get mission_control_jobs.application_batches_url(@application)
+    assert_response :ok
+    assert_select "a", text: "Batches", count: 1
+
+    @server.queue_adapter.stubs(:supports_batches?).returns(false)
+
+    get mission_control_jobs.application_batches_url(@application)
+    assert_redirected_to mission_control_jobs.root_url
+
+    get mission_control_jobs.application_batch_url(@application, 987654)
+    assert_redirected_to mission_control_jobs.root_url
+
+    get mission_control_jobs.application_jobs_url(@application, :pending)
+    assert_response :ok
+    assert_select "a", text: "Batches", count: 0
+  end
+
+  test "get batch list when there are no batches" do
+    get mission_control_jobs.application_batches_url(@application)
+    assert_response :ok
+
+    assert_select "tr.batch", 0
+    assert_select "li.is-active a", "Unfinished"
+    assert_select "div", text: "No unfinished batches found"
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "all")
+    assert_response :ok
+
+    assert_select "tr.batch", 0
+    assert_select "div", text: "There are no batches"
+  end
+
+  test "paginate batches" do
+    12.times { |i| create_batch(description: "Batch #{i}") }
+
+    get mission_control_jobs.application_batches_url(@application)
+    assert_response :ok
+
+    assert_select "tr.batch", 10
+    assert_select "nav[aria-label=\"pagination\"]", /1 \/ 2/
+    assert_select "nav[aria-label=\"pagination\"] a[href*=?]", "batches_status=unfinished"
+    assert_select "a.pagination-next", text: "↠", count: 1
+
+    get mission_control_jobs.application_batches_url(@application, page: 2)
+    assert_response :ok
+
+    assert_select "tr.batch", 2
+  end
+
+  test "filter batches by status" do
+    create_batch(description: "Still going")
+    finished = create_batch(description: "All done")
+    failed = create_batch(description: "Went wrong")
+    SolidQueue::Job.where(batch_id: finished.id).each { |job| finish(job) }
+    SolidQueue::Job.where(batch_id: failed.id).each { |job| fail_job(job, RuntimeError.new("boom")) }
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "finished")
+    assert_response :ok
+
+    assert_select "td", "All done"
+    assert_select "td", "Went wrong"
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "unfinished")
+    assert_response :ok
+
+    assert_select "tr.batch", 1
+    assert_select "td", "Still going"
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "failed")
+    assert_response :ok
+
+    assert_select "tr.batch", 1
+    assert_select "td", "Went wrong"
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "all")
+    assert_response :ok
+
+    assert_select "tr.batch", 3
+  end
+
+  test "get batch list defaulting to the unfinished batches" do
+    create_batch(description: "Still going")
+    finished = create_batch(description: "All done")
+    SolidQueue::Job.where(batch_id: finished.id).each { |job| finish(job) }
+
+    get mission_control_jobs.application_batches_url(@application)
+    assert_response :ok
+
+    assert_select "tr.batch", 1
+    assert_select "td", "Still going"
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "finished")
+    assert_response :ok
+
+    assert_select "tr.batch", 1
+    assert_select "td", "All done"
+  end
+
+  test "get batch list filtered by a status without matches" do
+    create_batch(description: "Still going")
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "finished")
+    assert_response :ok
+
+    assert_select "tr.batch", 0
+    assert_select "div", text: "No finished batches found"
+  end
+
+  test "paginate batches preserving the all population" do
+    12.times { |i| create_batch(description: "Batch #{i}") }
+    SolidQueue::Batch.order(:id).limit(3).each { |batch| SolidQueue::Job.where(batch_id: batch.id).each { |job| finish(job) } }
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "all")
+    assert_response :ok
+
+    assert_select "tr.batch", 10
+
+    next_page_url = css_select("a.pagination-next").find { |link| link.text == "Next page" }["href"]
+    assert_includes next_page_url, "batches_status=all"
+
+    get next_page_url
+    assert_response :ok
+
+    assert_select "li.is-active a", "All"
+    assert_select "tr.batch", 2
+  end
+
+  test "count batches once per request" do
+    12.times { create_batch }
+
+    queries = capture_select_queries do
+      get mission_control_jobs.application_batches_url(@application)
+    end
+    assert_response :ok
+
+    count_queries = queries.grep(/\ASELECT COUNT\(\*\) FROM .*solid_queue_batches/i)
+    assert_equal 1, count_queries.size, count_queries.join("\n\n")
+
+    fetch_queries = queries.grep(/\ASELECT "?solid_queue_batches"?\.\* FROM/i)
+    assert_equal 1, fetch_queries.size, fetch_queries.join("\n\n")
+  end
+
+  test "hide the jump-to-last link when the batches count is capped" do
+    12.times { create_batch }
+    original_limit = MissionControl::Jobs.internal_query_count_limit
+    MissionControl::Jobs.internal_query_count_limit = 5
+
+    get mission_control_jobs.application_batches_url(@application)
+    assert_response :ok
+
+    assert_select "nav[aria-label=\"pagination\"]", /1 \/ \.\.\./
+    assert_select "a.pagination-next", text: "↠", count: 0
+    assert_select "a.pagination-next", text: "Next page", count: 1
+  ensure
+    MissionControl::Jobs.internal_query_count_limit = original_limit
+  end
+
+  test "get batch details and pending job list" do
+    batch = create_batch(description: "Nightly imports", jobs: 2)
+
+    get mission_control_jobs.application_batch_url(@application, batch.id)
+    assert_response :ok
+
+    assert_select "h1", /Batch #{batch.id}/
+    assert_select "h2", "2 pending jobs"
+    assert_select "tr.job", 2
+  end
+
+  test "get batch details filtered by each unfinished job status" do
+    batch = create_batch_with_unfinished_statuses
+
+    get mission_control_jobs.application_batch_url(@application, batch.id)
+    assert_response :ok
+
+    assert_select "td a", "1 pending"
+    assert_select "td a", "1 in progress"
+    assert_select "td a", "1 blocked"
+    assert_select "td a", "1 scheduled"
+
+    %w[ pending in_progress blocked scheduled ].each do |status|
+      get mission_control_jobs.application_batch_url(@application, batch.id, jobs_status: status)
+      assert_response :ok
+
+      assert_select "h2", "1 #{status.dasherize} job"
+      assert_select "tr.job", 1
+    end
+  end
+
+  test "get batch details listing only that batch's jobs" do
+    batch = create_batch(jobs: 2)
+    other_batch = create_batch(jobs: 2)
+    BatchedJob.perform_later(99)
+    finish SolidQueue::Job.where(batch_id: batch.id).order(:id).first
+    SolidQueue::Job.where(batch_id: other_batch.id).each { |job| finish(job) }
+
+    get mission_control_jobs.application_batch_url(@application, batch.id, jobs_status: :pending)
+    assert_response :ok
+
+    assert_select "h2", "1 pending job"
+    assert_select "tr.job", 1
+
+    get mission_control_jobs.application_batch_url(@application, batch.id, jobs_status: :finished)
+    assert_response :ok
+
+    assert_select "h2", "1 finished job"
+    assert_select "tr.job", 1
+  end
+
+  test "get batch details for a completed batch" do
+    batch = create_batch(jobs: 2)
+    SolidQueue::Job.where(batch_id: batch.id).each { |job| finish(job) }
+
+    get mission_control_jobs.application_batch_url(@application, batch.id)
+    assert_response :ok
+
+    assert_select "span.tag", "completed"
+    assert_select "h2", "2 finished jobs"
+    assert_select "tr.job", 2
+  end
+
+  test "get batch details filtered by job status" do
+    batch = create_batch(jobs: 3)
+    finish SolidQueue::Job.where(batch_id: batch.id).order(:id).first
+
+    get mission_control_jobs.application_batch_url(@application, batch.id, jobs_status: :finished)
+    assert_response :ok
+
+    assert_select "h2", "1 finished job"
+    assert_select "tr.job", 1
+  end
+
+  test "get batch details for a batch with only scheduled jobs" do
+    batch = create_batch(jobs: 2, wait: 1.hour)
+
+    get mission_control_jobs.application_batch_url(@application, batch.id)
+    assert_response :ok
+
+    assert_select "h2", "2 scheduled jobs"
+    assert_select "tr.job", 2
+  end
+
+  test "get batch details with finished jobs" do
+    batch = create_batch(jobs: 4)
+    finish SolidQueue::Job.where(batch_id: batch.id).order(:id).first
+
+    get mission_control_jobs.application_batch_url(@application, batch.id)
+    assert_response :ok
+
+    assert_select "td a", "1 completed"
+    assert_select "td a", "3 pending"
+    assert_select "td", /of 4 total/
+  end
+
+  test "get batch details for a failed batch" do
+    batch = create_batch(description: "Doomed", jobs: 2)
+    jobs = SolidQueue::Job.where(batch_id: batch.id).order(:id).to_a
+    fail_job jobs.first, RuntimeError.new("boom went the job")
+    finish jobs.second
+
+    get mission_control_jobs.application_batch_url(@application, batch.id)
+    assert_response :ok
+
+    assert_select "span.tag", "failed"
+    assert_select "h2", "1 failed job"
+    assert_select "tr.job", 1
+    assert_select "td", /boom went the job/
+    assert_select "td a", "1 failed"
+  end
+
+  test "get batch list and details for a batch enqueued with no jobs" do
+    SolidQueue::Batch.enqueue(description: "No work") { }
+
+    get mission_control_jobs.application_batches_url(@application, batches_status: "finished")
+    assert_response :ok
+
+    assert_select "tr.batch", 1
+    assert_select "td", "No work"
+    assert_select "span.tag", "completed"
+
+    get mission_control_jobs.application_batch_url(@application, SolidQueue::Batch.last.id)
+    assert_response :ok
+
+    assert_select "td", /of 0 total/
+  end
+
+  test "paginate batch jobs preserving the job status" do
+    batch = create_batch(jobs: 3)
+    SolidQueue::Job.where(batch_id: batch.id).find_each { |job| finish(job) }
+
+    stub_const(MissionControl::Jobs::Page, :DEFAULT_PAGE_SIZE, 2) do
+      get mission_control_jobs.application_batch_url(@application, batch.id, jobs_status: :finished)
+      assert_response :ok
+
+      next_page_url = css_select("a.pagination-next").find { |link| link.text == "Next page" }["href"]
+      assert_includes next_page_url, "jobs_status=finished"
+
+      get next_page_url
+      assert_response :ok
+
+      assert_select "h2", "3 finished jobs"
+      assert_select "tr.job", 1
+    end
+  end
+
+  test "get job details for a batched job" do
+    batch = create_batch(description: "Nightly imports")
+    job = SolidQueue::Job.where(batch_id: batch.id).sole
+
+    get mission_control_jobs.application_job_url(@application, job.active_job_id)
+    assert_response :ok
+
+    assert_select "th", "Part of"
+    assert_select "td a[href=?]", mission_control_jobs.application_batch_path(@application, batch.id), text: "batch #{batch.id}"
+  end
+
+  test "get job details for an unbatched job" do
+    job = BatchedJob.perform_later(1)
+
+    get mission_control_jobs.application_job_url(@application, job.job_id)
+    assert_response :ok
+
+    assert_select "th", text: "Part of", count: 0
+  end
+
+  test "redirect to batches list when batch doesn't exist" do
+    get mission_control_jobs.application_batch_url(@application, 987654)
+    assert_redirected_to mission_control_jobs.application_batches_url(@application)
+
+    follow_redirect!
+
+    assert_select "article.is-danger", /Batch with id '987654' not found/
+  end
+
+  private
+    def create_batch(description: nil, jobs: 1, wait: nil)
+      SolidQueue::Batch.enqueue(description: description) do
+        jobs.times do |i|
+          wait ? BatchedJob.set(wait: wait).perform_later(i) : BatchedJob.perform_later(i)
+        end
+      end
+    end
+
+    def create_batch_with_unfinished_statuses
+      batch = SolidQueue::Batch.enqueue do
+        3.times { |i| BatchedJob.perform_later(i) }
+        BatchedJob.set(wait: 1.hour).perform_later(3)
+      end
+
+      claimed_job_id, blocked_job_id = SolidQueue::ReadyExecution.where(job_id: batch.jobs.ids).order(:job_id).limit(2).pluck(:job_id)
+      SolidQueue::ReadyExecution.where(job_id: [ claimed_job_id, blocked_job_id ]).delete_all
+
+      SolidQueue::ClaimedExecution.insert_all!([ { job_id: claimed_job_id, process_id: nil, created_at: Time.current } ])
+      SolidQueue::Job.where(id: blocked_job_id).update_all(concurrency_key: "batch-key")
+      SolidQueue::BlockedExecution.insert_all!([ {
+        job_id: blocked_job_id,
+        queue_name: "default",
+        priority: 0,
+        concurrency_key: "batch-key",
+        expires_at: 1.hour.from_now,
+        created_at: Time.current
+      } ])
+
+      batch
+    end
+
+    def finish(job)
+      SolidQueue::ReadyExecution.where(job_id: job.id).destroy_all
+      job.finished!
+    end
+
+    def fail_job(job, error)
+      SolidQueue::ReadyExecution.where(job_id: job.id).destroy_all
+      job.failed_with(error)
+    end
+end

--- a/test/controllers/workers_controller_test.rb
+++ b/test/controllers/workers_controller_test.rb
@@ -8,11 +8,18 @@ class MissionControl::Jobs::WorkersControllerTest < ActionDispatch::IntegrationT
 
   test "get workers" do
     perform_enqueued_jobs_async(wait: 0) do
+      wait_for_claimed_executions(2)
       worker = @server.workers_relation.first
       get mission_control_jobs.application_workers_url(@application)
 
       assert_select "tr.worker", 1
       assert_select "tr.worker", /worker #{worker.id}\s+PID: \d+\s+my-hostname-123\s+PauseJob/
+    end
+  end
+
+  test "workers are registered by the time performing jobs asynchronously returns" do
+    perform_enqueued_jobs_async(wait: 0) do
+      assert_not_nil @server.workers_relation.first
     end
   end
 
@@ -30,6 +37,7 @@ class MissionControl::Jobs::WorkersControllerTest < ActionDispatch::IntegrationT
 
   test "get worker details" do
     perform_enqueued_jobs_async(wait: 0) do
+      wait_for_claimed_executions(2)
       worker = @server.workers_relation.first
 
       get mission_control_jobs.application_worker_url(@application, worker.id)

--- a/test/dummy/db/queue_schema.rb
+++ b/test/dummy/db/queue_schema.rb
@@ -37,7 +37,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "batch_id"
     t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index [ "batch_id" ], name: "index_solid_queue_jobs_on_batch_id"
     t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
     t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
     t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
@@ -120,6 +122,35 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "solid_queue_batches", force: :cascade do |t|
+    t.string "active_job_batch_id"
+    t.string "description"
+    t.text "on_finish"
+    t.text "on_success"
+    t.text "on_failure"
+    t.text "metadata"
+    t.integer "total_jobs", default: 0, null: false
+    t.integer "completed_jobs", default: 0, null: false
+    t.integer "failed_jobs", default: 0, null: false
+    t.datetime "enqueued_at"
+    t.datetime "finished_at"
+    t.datetime "failed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "active_job_batch_id" ], name: "index_solid_queue_batches_on_active_job_batch_id", unique: true
+    t.index [ "finished_at" ], name: "index_solid_queue_batches_on_finished_at"
+  end
+
+  create_table "solid_queue_batch_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "batch_id", null: false
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_batch_executions_on_job_id", unique: true
+    t.index [ "batch_id" ], name: "index_solid_queue_batch_executions_on_batch_id"
+  end
+
+  add_foreign_key "solid_queue_batch_executions", "solid_queue_batches", column: "batch_id", on_delete: :cascade
+  add_foreign_key "solid_queue_batch_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/test/mission_control/jobs/batches_relation_test.rb
+++ b/test/mission_control/jobs/batches_relation_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class MissionControl::Jobs::BatchesRelationTest < ActiveSupport::TestCase
+  class StubAdapter
+    def initialize(count)
+      @count = count
+    end
+
+    def count_batches(_batches_relation)
+      @count
+    end
+
+    def fetch_batches(_batches_relation)
+      []
+    end
+  end
+
+  setup do
+    @batches_relation = MissionControl::Jobs::BatchesRelation.new(queue_adapter: ActiveJob::Base.queue_adapter)
+  end
+
+  test "set limit and offset" do
+    assert_equal 0, @batches_relation.offset_value
+
+    batches = @batches_relation.offset(10).limit(20)
+
+    assert_equal 10, batches.offset_value
+    assert_equal 20, batches.limit_value
+  end
+
+  test "count is clamped into the pagination window" do
+    batches = MissionControl::Jobs::BatchesRelation.new(queue_adapter: StubAdapter.new(5))
+
+    assert_equal 5, batches.count
+    assert_equal 2, batches.offset(3).limit(3).count
+    assert_equal 0, batches.offset(10).limit(3).count
+    assert batches.offset(10).limit(3).empty?
+  end
+
+  test "an internally capped count flows through when no limit is given" do
+    batches = MissionControl::Jobs::BatchesRelation.new(queue_adapter: StubAdapter.new(Float::INFINITY))
+
+    assert_equal Float::INFINITY, batches.count
+  end
+end

--- a/test/support/queries_helper.rb
+++ b/test/support/queries_helper.rb
@@ -1,0 +1,13 @@
+module QueriesHelper
+  extend ActiveSupport::Concern
+
+  def capture_select_queries
+    queries = []
+    subscriber = lambda do |*, payload|
+      queries << payload[:sql] if payload[:sql].match?(/\ASELECT\b/i)
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") { yield }
+    queries
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ Dir[File.join(__dir__, "active_job", "queue_adapters", "adapter_testing", "*.rb"
 ENV["FORK_PER_JOB"] = "false" # Disable forking when dispatching resque jobs
 
 class ActiveSupport::TestCase
-  include JobsHelper, JobQueuesHelper, ThreadHelper
+  include JobsHelper, JobQueuesHelper, QueriesHelper, ThreadHelper
 
   setup do
     @original_applications = MissionControl::Jobs.applications
@@ -61,6 +61,7 @@ class ActiveSupport::TestCase
       SolidQueue::Job.find_each(&:destroy)
       SolidQueue::Process.find_each(&:destroy)
       SolidQueue::RecurringTask.find_each(&:destroy)
+      SolidQueue::Batch.find_each(&:destroy)
     end
 
     def root_resque_redis
@@ -73,6 +74,11 @@ class ActiveSupport::TestCase
 end
 
 class ActionDispatch::IntegrationTest
+  ASYNC_TIMEOUT = 10.seconds
+  ASYNC_POLLING_INTERVAL = 0.01
+  SOLID_QUEUE_MODEL_NAMES = %w[ Batch BatchExecution BlockedExecution ClaimedExecution FailedExecution
+    Job Pause Process ReadyExecution RecurringExecution RecurringTask ScheduledExecution Semaphore ]
+
   # Integration tests just use Solid Queue for now
   setup do
     MissionControl::Jobs.applications.add("integration-tests", { solid_queue: queue_adapter_for_test })
@@ -99,8 +105,12 @@ class ActionDispatch::IntegrationTest
       count.times { |i| SolidQueue::Process.register(kind: "Worker", pid: i, name: "worker-#{i}") }
     end
 
+    # Solid Queue boots processes asynchronously, so the worker isn't registered when
+    # +start+ returns. Wait for it before giving the jobs the requested processing time.
     def perform_enqueued_jobs_async(wait: 1.second)
+      preload_solid_queue_schemas
       @worker.start
+      wait_for_worker_registration
       sleep(wait)
 
       yield if block_given?
@@ -113,5 +123,35 @@ class ActionDispatch::IntegrationTest
 
       yield if block_given?
       @scheduler.stop
+    end
+
+    # Transactional tests pin a single connection that the worker thread shares. Loading a
+    # model's schema holds a class-level lock while it queries, so a model first touched
+    # from the test thread while the worker holds that connection deadlocks the two. Warming
+    # the schemas up before any worker starts keeps both threads off that path.
+    def preload_solid_queue_schemas
+      SOLID_QUEUE_MODEL_NAMES.each { |name| SolidQueue.const_get(name).load_schema }
+    end
+
+    def wait_for_worker_registration
+      wait_until("the worker to register") { @worker.process_id.present? }
+    end
+
+    def wait_for_claimed_executions(count)
+      wait_until("#{count} claimed executions") { SolidQueue::ClaimedExecution.count >= count }
+    end
+
+    def wait_until(condition, timeout: ASYNC_TIMEOUT)
+      deadline = monotonic_now + timeout
+
+      until yield
+        raise "Timed out after #{timeout.inspect} waiting for #{condition}" if monotonic_now > deadline
+
+        sleep ASYNC_POLLING_INTERVAL
+      end
+    end
+
+    def monotonic_now
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
     end
 end


### PR DESCRIPTION
> **WIP — Opening as a reference point for anyone looking for batch support in MissionControl - but I haven't finished refining it yet

Batch support for Solid Queue in Mission Control, built against the released **solid_queue 1.7.0** — batches shipped upstream in rails/solid_queue#142, so this depends on a normal gem release with no branch pins.

## What's here

Batches follow the recurring-tasks and workers architecture end to end.

- **Adapter capability**: `supports_batches?` (false by default) plus `batches(status:, offset:, limit:)`, `batches_count(status:)` and `find_batch`, all returning attribute hashes so the UI never touches a backend's classes. Adapters that don't claim support are unaffected; one that claims it but misses a method gets the usual `IncompatibleAdapter` error.
- **Solid Queue adapter** (`SolidQueueExt::Batches`): symbol statuses, `total/completed/failed/pending` plus per-state job counts, `progress_percentage`, metadata and timestamps. Support detection checks the models *and* every column it reads, so an app on an older Solid Queue — or one that hasn't run the optional batches migration — simply doesn't get the tab.
- **Built for large installs**: all per-batch counters come back in one query via correlated subqueries, `CASE`-guarded on `finished_at` so finished rows use their stored counters instead of counting live executions. `batches_count` is capped by `internal_query_count_limit` and returns `Float::INFINITY` past it, mirroring the existing jobs behaviour. Listing finished or failed batches skips the live count subqueries entirely.
- **Batches UI**: capability-gated tab; paginated index with All / Unfinished / Finished / Failed filters (defaulting to Unfinished, since that's the actionable population and the finished one can be arbitrarily large); show page with progress, linked per-status counters and the batch's jobs rendered through the standard per-status partials — failed batches default to their failed jobs with full error details and retry/discard actions, switchable via `jobs_status` exactly like the jobs index.
- **Job → batch link**: a batched job's show page gets a "Part of" row linking back to its batch, so you can go from a failed job to the rest of its batch. `JobProxy#batch_id` is defined on the proxy rather than on `ActiveJob::Base` deliberately: Solid Queue defines its own `batch_id` there for capturing batch membership at enqueue, and shadowing it would break real batching in apps running both.
- **Job filtering**: `JobsRelation` gains `batch_id`, applied through the job association on the executions path and directly on the finished path, so a batch's jobs resolve across every status.
- **Wiring**: server concern, `ResourceNotFound` → batches index redirect, routes, navigation entry, dummy queue schema.

## Fixes outside the feature

Two changes here aren't batch features but are needed for the suite to be honest:

- `Page#records` returned a fresh relation on every call, so rendering a page plus the toolbar's two `last?` checks re-ran the (capped, potentially expensive) count **four times per request**. It's materialized once now — verified 4 → 1 on the batches index. This affects every paginated page, not just batches.
- Solid Queue 1.7 registers worker processes asynchronously, which made the existing worker controller tests race and fail. `perform_enqueued_jobs_async` now waits for registration on a bounded deadline instead of a fixed `sleep`. That wait also required pre-loading the Solid Queue models' schemas: a test thread first touching a cold model while the worker holds the transactionally-pinned connection deadlocks on Active Record's per-model schema lock.

Also: the pagination toolbar hides its jump-to-last control when the total is capped (`pages_count` is nil, so the link went to page 1), and the adapter clamps derived counts at zero — a retry and its unfinished previous attempt can both hold tracking rows for one logical job, which briefly produced negative "completed" counts and progress.

## Testing

- Full suite green: **262 runs, 1541 assertions, 0 failures, 0 errors** (the 1 skip is a pre-existing Resque one on main). System tests pass too, which matters because `Page#records` touches every paginated screen.
- 21 controller tests covering the index, status filters, pagination (including that the All filter survives paging), empty states, batch details, per-status job lists, progress with failures, error details, the job→batch link, and the not-found redirect. 8 adapter tests covering the single-query listing, the count cap, the finished/failed subquery skip, and the retry-overlap clamp.
- Exercised against real workers — supervisor and dispatcher on the dummy app — with batches completing, failing and firing callbacks through the genuine claim/perform flow, and checked in a browser.
- Reviewed with an independent model at high reasoning effort; its findings are the "fixes outside the feature" above plus the clamp and the toolbar fix.

## Notes for review

- The gemspec's dev dependency moves from `solid_queue ~> 1.0.1` to `~> 1.0` so 1.7 resolves. The `minitest ~> 5.25` pin in the Gemfile is unrelated to batches — minitest 6 breaks railties 7.2 line filtering — and can be dropped if it's fixed elsewhere.
- Batches are an optional migration in Solid Queue 1.x and become part of the base schema in 2.0. The column checks in `supports_batches?` mean an app that hasn't migrated sees no Batches tab rather than an error.
