### PR TITLE
Redirect to queues index when showing a queue that no longer exists

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/not_found_redirections.rb
+++ b/app/controllers/concerns/mission_control/jobs/not_found_redirections.rb
@@ -24,8 +24,11 @@ module MissionControl::Jobs::NotFoundRedirections
     end
 
     def best_location_for_resource_not_found_error(error)
-      if error.message.match?(/recurring task/i)
+      case error.message
+      when /recurring task/i
         application_recurring_tasks_path(@application)
+      when /queue/i
+        application_queues_path(@application)
       else
         root_url
       end

--- a/app/controllers/mission_control/jobs/queues_controller.rb
+++ b/app/controllers/mission_control/jobs/queues_controller.rb
@@ -11,6 +11,6 @@ class MissionControl::Jobs::QueuesController < MissionControl::Jobs::Application
 
   private
     def set_queue
-      @queue = ActiveJob.queues[params[:id]]
+      @queue = ActiveJob.queues[params[:id]] or raise MissionControl::Jobs::Errors::ResourceNotFound, "Queue '#{params[:id]}' not found"
     end
 end

--- a/test/controllers/queues_controller_test.rb
+++ b/test/controllers/queues_controller_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class MissionControl::Jobs::QueuesControllerTest < ActionDispatch::IntegrationTest
+  test "redirect to queues index when queue doesn't exist" do
+    get mission_control_jobs.application_queue_url(@application, "missing_queue")
+    assert_redirected_to mission_control_jobs.application_queues_url(@application)
+    follow_redirect!
+
+    assert_select "article.is-danger", /Queue 'missing_queue' not found/
+  end
+end


### PR DESCRIPTION
### Problem

With adapters like Solid Queue, a queue only exists while there are job rows carrying its name (`SolidQueue::Queue.all` is a `DISTINCT queue_name` over `solid_queue_jobs`). So a queue can disappear between rendering the queues index and visiting its show page — especially with `preserve_finished_jobs = false` and fast workers, where a queue vanishes the moment it drains.

When that happens, `QueuesController#show` crashes with a 500:

```
NoMethodError: undefined method 'jobs' for nil

    @jobs_page = MissionControl::Jobs::Page.new(@queue.jobs, page: params[:page].to_i)
                                                      ^^^^^
```

### Fix

Raise `MissionControl::Jobs::Errors::ResourceNotFound` when the queue lookup returns nil, mirroring what the `QueueScoped` concern already does for `Queues::PausesController`.

Also redirect queue-related not-found errors to the queues index instead of root. Root redirects to the queues index anyway, and that extra redirect consumed the flash before it could be rendered — so previously the `QueueScoped` path would land on the right page but silently drop the "Queue 'x' not found" alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)