### PR TITLE
Route host app helpers used inside the engine through main_app

### DIFF
--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -9,6 +9,7 @@ class MissionControl::Jobs::ApplicationController < MissionControl::Jobs.base_co
   helper MissionControl::Jobs::ApplicationHelper unless self < MissionControl::Jobs::ApplicationHelper
   helper Importmap::ImportmapTagsHelper unless self < Importmap::ImportmapTagsHelper
 
+  include MissionControl::Jobs::HostRouteHelpers
   include MissionControl::Jobs::BasicAuthentication
   include MissionControl::Jobs::ApplicationScoped, MissionControl::Jobs::NotFoundRedirections
   include MissionControl::Jobs::AdapterFeatures

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -34,6 +34,12 @@ module MissionControl
         end
       end
 
+      initializer "mission_control-jobs.host_route_helpers" do |app|
+        ActiveSupport.on_load(:after_routes_loaded) do
+          MissionControl::Jobs::HostRouteHelpers.define_from(app.routes, MissionControl::Jobs::Engine.routes)
+        end
+      end
+
       initializer "mission_control-jobs.http_basic_auth" do |app|
         MissionControl::Jobs.http_basic_auth_user ||= app.credentials.dig(:mission_control, :http_basic_auth_user)
         MissionControl::Jobs.http_basic_auth_password ||= app.credentials.dig(:mission_control, :http_basic_auth_password)

--- a/lib/mission_control/jobs/host_route_helpers.rb
+++ b/lib/mission_control/jobs/host_route_helpers.rb
@@ -1,0 +1,33 @@
+# Route helpers of the host app that the engine doesn't define itself, routed through +main_app+.
+#
+# Mission Control's controllers inherit from the host app's +ApplicationController+ (see
+# +base_controller_class+), so host code such as a +before_action+ redirecting to
+# +new_session_path+ runs inside the engine, where route helpers resolve against the engine's
+# routes and raise +ActionController::UrlGenerationError+. This module defines, for every route
+# helper the host app has and the engine doesn't, a method delegating to the host app's routes,
+# so that code keeps working unchanged.
+#
+# Helpers defined by both, like +root_path+, keep resolving to the engine's, as in any isolated
+# engine; use +main_app.root_path+ for the host's.
+module MissionControl::Jobs::HostRouteHelpers
+  class << self
+    def define_from(host_routes, engine_routes)
+      undefine_all
+
+      (host_routes.named_routes.helper_names - engine_routes.named_routes.helper_names).each do |name|
+        define_method(name) { |*args| main_app.public_send(name, *args) }
+        defined_helpers << name
+      end
+    end
+
+    private
+      def undefine_all
+        defined_helpers.each { |name| remove_method(name) }
+        defined_helpers.clear
+      end
+
+      def defined_helpers
+        @defined_helpers ||= []
+      end
+  end
+end

--- a/test/controllers/host_route_helpers_test.rb
+++ b/test/controllers/host_route_helpers_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class MissionControl::Jobs::HostRouteHelpersTest < ActionDispatch::IntegrationTest
+  test "host route helpers used by the base controller resolve against the host app's routes" do
+    get mission_control_jobs.application_queues_url(@application, require_authentication: true)
+    assert_redirected_to "/session/new"
+  end
+
+  test "route helpers defined by both the host app and the engine keep resolving to the engine's" do
+    assert_includes MissionControl::Jobs::HostRouteHelpers.instance_methods, :new_session_path
+    assert_not_includes MissionControl::Jobs::HostRouteHelpers.instance_methods, :root_path
+  end
+
+  test "host route helpers are redefined when routes reload" do
+    Rails.application.reload_routes!
+
+    assert_includes MissionControl::Jobs::HostRouteHelpers.instance_methods, :new_session_path
+    get mission_control_jobs.application_queues_url(@application, require_authentication: true)
+    assert_redirected_to "/session/new"
+  end
+end

--- a/test/dummy/app/controllers/my_application_controller.rb
+++ b/test/dummy/app/controllers/my_application_controller.rb
@@ -1,2 +1,10 @@
 class MyApplicationController < ApplicationController
+  # Mimics host authentication redirecting to a host route from inside the engine, as
+  # Rails' authentication generator does with +new_session_path+.
+  before_action :require_authentication, if: -> { params[:require_authentication] }
+
+  private
+    def require_authentication
+      redirect_to new_session_path
+    end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root to: redirect("/jobs")
+  resource :session, only: :new
 
   mount MissionControl::Jobs::Engine => "/jobs"
 end


### PR DESCRIPTION
Mission Control's controllers inherit from the host app's `ApplicationController` (`base_controller_class`), so host code such as a `before_action` redirecting to `new_session_path` — what Rails 8's authentication generator does — runs inside the engine, where route helpers resolve against the engine's routes and raise `ActionController::UrlGenerationError` (#245).

This defines, for every route helper the host app has and the engine doesn't, a delegator to `main_app`, (re)defined whenever routes load, so that code keeps working unchanged with the default base controller or a custom one like `AdminController`. Helpers both sides define, like `root_path`, keep resolving to the engine's, as in any isolated engine — `main_app.root_path` remains the way to reach the host's.

Fixes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01451tkCm8XN85boSpVpgSjV
