### PR TITLE
Add copy action to failed job details

### DIFF
--- a/app/helpers/mission_control/jobs/jobs_helper.rb
+++ b/app/helpers/mission_control/jobs/jobs_helper.rb
@@ -23,6 +23,26 @@ module MissionControl::Jobs::JobsHelper
     end
   end
 
+  def job_copy_text(job, server)
+    [
+      "Job: #{job.job_class_name}",
+      "Job id: #{job.job_id}",
+      "Queue: #{job.queue_name}",
+      "",
+      "Arguments:",
+      job_arguments(job).presence || "[none]",
+      "",
+      "Error:",
+      failed_job_error(job),
+      "",
+      "Backtrace:",
+      failed_job_backtrace(job, server).presence || "[none]",
+      "",
+      "Raw data:",
+      JSON.pretty_generate(job.filtered_raw_data.without("backtrace"))
+    ].join("\n")
+  end
+
   def attribute_names_for_job_status(status)
     case status.to_s
     when "failed"      then [ "Error", "" ]

--- a/app/javascript/mission_control/jobs/controllers/copy_controller.js
+++ b/app/javascript/mission_control/jobs/controllers/copy_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["source", "button"]
+
+  connect() {
+    this.originalText = this.buttonTarget.textContent
+  }
+
+  copy() {
+    navigator.clipboard
+      .writeText(this.sourceTarget.textContent)
+      .then(() => this.showMessage("Copied!"), () => this.showMessage("Copy failed!"))
+  }
+
+  showMessage(message) {
+    clearTimeout(this.timeout)
+    this.buttonTarget.textContent = message
+    this.timeout = setTimeout(() => {
+      this.buttonTarget.textContent = this.originalText
+      this.timeout = null
+    }, 1000)
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+}

--- a/app/views/mission_control/jobs/jobs/_title.html.erb
+++ b/app/views/mission_control/jobs/jobs/_title.html.erb
@@ -6,6 +6,7 @@
     </div>
     <div class="level-right">
       <% if job.failed? %>
+        <%= render "mission_control/jobs/jobs/failed/copy", job: job %>
         <%= render "mission_control/jobs/jobs/failed/actions", job: job %>
       <% end %>
       <% if job.blocked? %>

--- a/app/views/mission_control/jobs/jobs/failed/_copy.html.erb
+++ b/app/views/mission_control/jobs/jobs/failed/_copy.html.erb
@@ -1,0 +1,4 @@
+<%= tag.div data: { controller: "copy" } do %>
+  <%= button_tag "Copy as text", type: "button", class: "button is-info is-light mr-0", data: { action: "copy#copy", copy_target: "button" } %>
+  <%= tag.pre job_copy_text(job, @server), data: { copy_target: "source" }, class: "is-hidden" %>
+<% end %>

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -44,6 +44,34 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tr", /Retries\s+2/
   end
 
+  test "failed job details include copy as text button" do
+    job = FailingJob.perform_later(42)
+
+    perform_enqueued_jobs_async
+
+    get mission_control_jobs.application_job_url(@application, job.job_id)
+    assert_response :ok
+
+    assert_select "button[data-action='copy#copy']", "Copy as text"
+    copy_text = css_select("pre[data-copy-target='source']").first.text
+    assert_match(/Job: FailingJob/, copy_text)
+    assert_match(/Job id: #{job.job_id}/, copy_text)
+    assert_match(/Arguments:.*42/m, copy_text)
+    assert_match(/RuntimeError: This always fails!/, copy_text)
+    assert_match(/failing_job.rb/, copy_text)
+    assert_match(/"job_class": "FailingJob"/, copy_text)
+  end
+
+  test "copy as text button is not rendered for non failed jobs" do
+    job = DummyJob.perform_later(42)
+
+    get mission_control_jobs.application_job_url(@application, job.job_id)
+    assert_response :ok
+
+    assert_no_match(/Copy as text/, response.body)
+    assert_no_match(/data-copy-target="source"/, response.body)
+  end
+
   test "get scheduled jobs flagging retries" do
     DummyJob.set(wait: 1.hour).perform_later(42)
     DummyJob.new(43).tap { |job| job.executions = 1 }.enqueue(wait: 1.hour)

--- a/test/system/show_failed_job_test.rb
+++ b/test/system/show_failed_job_test.rb
@@ -16,6 +16,59 @@ class ShowFailedJobsTest < ApplicationSystemTestCase
     assert_text /failing_job.rb/
   end
 
+  test "failed job details offer copy as text" do
+    within_job_row /FailingJob\s*2/ do
+      click_on "FailingJob"
+    end
+
+    assert_selector "button[data-action='copy#copy']", text: "Copy as text"
+
+    copy_source = find("pre[data-copy-target='source']", visible: false)
+    copy_text = page.evaluate_script("arguments[0].textContent", copy_source)
+    assert_match /Job: FailingJob/, copy_text
+    assert_match /Arguments:\s*2/, copy_text
+    assert_match /RuntimeError: This always fails!/, copy_text
+    assert_match /failing_job.rb/, copy_text
+  end
+
+  test "copy as text copies the job data to the clipboard" do
+    within_job_row /FailingJob\s*2/ do
+      click_on "FailingJob"
+    end
+
+    page.execute_script <<~JS
+      window.__copied = null
+      navigator.clipboard.writeText = (text) => { window.__copied = text; return Promise.resolve() }
+    JS
+
+    click_on "Copy as text"
+
+    copied_text = page.evaluate_script("window.__copied")
+    assert_match /Job: FailingJob/, copied_text
+    assert_match /RuntimeError: This always fails!/, copied_text
+    assert_match /failing_job.rb/, copied_text
+
+    assert page.evaluate_script(<<~JS)
+      document.querySelector("button[data-action='copy#copy']").textContent.trim() === "Copied!"
+    JS
+  end
+
+  test "shows a failure when copying the job data fails" do
+    within_job_row /FailingJob\s*2/ do
+      click_on "FailingJob"
+    end
+
+    page.execute_script <<~JS
+      navigator.clipboard.writeText = () => Promise.reject()
+    JS
+
+    click_on "Copy as text"
+
+    assert page.evaluate_script(<<~JS)
+      document.querySelector("button[data-action='copy#copy']").textContent.trim() === "Copy failed!"
+    JS
+  end
+
   test "filtered arguments are hidden" do
     ActiveJob.jobs.failed.discard_all
     FailingPostJob.perform_later(Post.create(title: "hello_world"), 1.year.ago, author: "Jorge")


### PR DESCRIPTION
Closes #324

Adds a one-click “Copy as text” action to the failed job details page. The copied text includes the job class, ID, queue, arguments, error, backtrace, and filtered raw data.

The action is intentionally available on the details page only, keeping the failed jobs list lightweight. Success and clipboard failure states are shown in the button and reset automatically.

Edit:
One point where I’d especially appreciate maintainer input is the copied text format. I chose a human-readable plain-text block with the job details and filtered raw data. If you prefer a particular convention for section order, labels, or whether the raw data should be included by default, I’m happy to adjust.