### PR TITLE
Add enqueued_at and scheduled_at date filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,11 @@ ActiveJob.jobs.finished.where(job_class_name: "SomeJob")
 # For adapters that support filtering by worker:
 # All jobs in progress being run by a given worker
 ActiveJob.jobs.in_progress.where(worker_id: 42)
+
+# Filtering by dates takes a range, which can be open on either end
+ActiveJob.jobs.failed.where(enqueued_at: 2.days.ago..)
+ActiveJob.jobs.scheduled.where(scheduled_at: Time.now..1.hour.from_now)
+ActiveJob.jobs.finished.where(finished_at: ..1.week.ago)
 ```
 
 Some examples of bulk operations:

--- a/app/assets/stylesheets/mission_control/jobs/jobs.css
+++ b/app/assets/stylesheets/mission_control/jobs/jobs.css
@@ -1,3 +1,9 @@
+.filter,
+.filter form {
+    max-width: 100%;
+    min-width: 0;
+}
+
 .filter input {
     width: 15rem;
 }

--- a/app/controllers/concerns/mission_control/jobs/job_filters.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_filters.rb
@@ -12,7 +12,9 @@ module MissionControl::Jobs::JobFilters
       @job_filters = {
         job_class_name: params.dig(:filter, :job_class_name).to_s.strip.presence,
         queue_name: params.dig(:filter, :queue_name).to_s.strip.presence,
-        finished_at: finished_at_range_params
+        finished_at: date_range_params(:finished_at),
+        scheduled_at: date_range_params(:scheduled_at),
+        enqueued_at: date_range_params(:enqueued_at)
       }.compact
     end
 
@@ -28,8 +30,8 @@ module MissionControl::Jobs::JobFilters
       end
     end
 
-    def finished_at_range_params
-      range_start, range_end = params.dig(:filter, :finished_at_start), params.dig(:filter, :finished_at_end)
+    def date_range_params(attribute)
+      range_start, range_end = params.dig(:filter, :"#{attribute}_start"), params.dig(:filter, :"#{attribute}_end")
       if range_start || range_end
         (parse_with_time_zone(range_start)..parse_with_time_zone(range_end))
       end

--- a/app/views/mission_control/jobs/jobs/_date_range_filter.html.erb
+++ b/app/views/mission_control/jobs/jobs/_date_range_filter.html.erb
@@ -2,14 +2,10 @@
 
 <div class="control">
   <%= form.label :"#{attribute}_start", "#{label} from", class: "label" %>
-  <div class="select is-rounded">
-    <%= form.datetime_field :"#{attribute}_start", value: @job_filters[attribute]&.begin, class: "input" %>
-  </div>
+  <%= form.datetime_field :"#{attribute}_start", value: @job_filters[attribute]&.begin, class: "input is-rounded" %>
 </div>
 
 <div class="control">
   <%= form.label :"#{attribute}_end", "#{label} to", class: "label" %>
-  <div class="select is-rounded">
-    <%= form.datetime_field :"#{attribute}_end", value: @job_filters[attribute]&.end, class: "input" %>
-  </div>
+  <%= form.datetime_field :"#{attribute}_end", value: @job_filters[attribute]&.end, class: "input is-rounded" %>
 </div>

--- a/app/views/mission_control/jobs/jobs/_date_range_filter.html.erb
+++ b/app/views/mission_control/jobs/jobs/_date_range_filter.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (form:, attribute:, label:) %>
+
+<div class="control">
+  <%= form.label :"#{attribute}_start", "#{label} from", class: "label" %>
+  <div class="select is-rounded">
+    <%= form.datetime_field :"#{attribute}_start", value: @job_filters[attribute]&.begin, class: "input" %>
+  </div>
+</div>
+
+<div class="control">
+  <%= form.label :"#{attribute}_end", "#{label} to", class: "label" %>
+  <div class="select is-rounded">
+    <%= form.datetime_field :"#{attribute}_end", value: @job_filters[attribute]&.end, class: "input" %>
+  </div>
+</div>

--- a/app/views/mission_control/jobs/jobs/_filters.html.erb
+++ b/app/views/mission_control/jobs/jobs/_filters.html.erb
@@ -2,7 +2,7 @@
   <%= form_for :filter, url: application_jobs_path(MissionControl::Jobs::Current.application, jobs_status), method: :get,
     data: { controller: "form", action: "change->form#submit" } do |form| %>
 
-    <div class="field is-grouped">
+    <div class="field is-grouped is-grouped-multiline">
       <div class="control">
         <%= form.label :job_class_name, class: "label" %>
         <div class="select is-rounded">
@@ -18,19 +18,13 @@
       </div>
 
       <% if jobs_status == "finished" %>
-        <div class="control">
-          <%= form.label :finished_at_start, class: "label" %>
-          <div class="select is-rounded">
-            <%= form.datetime_field :finished_at_start, value: @job_filters[:finished_at]&.begin, class: "input", placeholder: "Finished from" %>
-          </div>
-        </div>
+        <%= render "mission_control/jobs/jobs/date_range_filter", form: form, attribute: :finished_at, label: "Finished" %>
+      <% else %>
+        <%= render "mission_control/jobs/jobs/date_range_filter", form: form, attribute: :enqueued_at, label: "Enqueued" %>
+      <% end %>
 
-        <div class="control">
-          <%= form.label :finished_at_end, class: "label" %>
-          <div class="select is-rounded">
-            <%= form.datetime_field :finished_at_end, value: @job_filters[:finished_at]&.end, class: "input", placeholder: "Finished to" %>
-          </div>
-        </div>
+      <% if jobs_status == "scheduled" %>
+        <%= render "mission_control/jobs/jobs/date_range_filter", form: form, attribute: :scheduled_at, label: "Scheduled" %>
       <% end %>
 
       <%= hidden_field_tag :server_id, MissionControl::Jobs::Current.server.id %>

--- a/lib/active_job/jobs_relation.rb
+++ b/lib/active_job/jobs_relation.rb
@@ -23,9 +23,9 @@ class ActiveJob::JobsRelation
   include Enumerable
 
   STATUSES = %i[ pending failed in_progress blocked scheduled finished ]
-  FILTERS = %i[ queue_name job_class_name ]
+  FILTERS = %i[ queue_name job_class_name scheduled_at enqueued_at ]
 
-  PROPERTIES = %i[ queue_name status offset_value limit_value job_class_name worker_id recurring_task_id finished_at ]
+  PROPERTIES = %i[ queue_name status offset_value limit_value job_class_name worker_id recurring_task_id finished_at scheduled_at enqueued_at ]
   attr_reader(*PROPERTIES, :default_page_size)
 
   delegate :last, :[], :reverse, to: :to_a
@@ -52,13 +52,17 @@ class ActiveJob::JobsRelation
   # * <tt>:worker_id</tt> - To only include the jobs processed by the provided worker.
   # * <tt>:recurring_task_id</tt> - To only include the jobs corresponding to runs of a recurring task.
   # * <tt>:finished_at</tt> - (Range) To only include the jobs finished between the provided range
-  def where(job_class_name: nil, queue_name: nil, worker_id: nil, recurring_task_id: nil, finished_at: nil)
+  # * <tt>:scheduled_at</tt> - (Range) To only include the jobs scheduled between the provided range
+  # * <tt>:enqueued_at</tt> - (Range) To only include the jobs enqueued between the provided range
+  def where(job_class_name: nil, queue_name: nil, worker_id: nil, recurring_task_id: nil, finished_at: nil, scheduled_at: nil, enqueued_at: nil)
     # Remove nil arguments to avoid overriding parameters when concatenating +where+ clauses
     arguments = { job_class_name: job_class_name,
       queue_name: queue_name&.to_s,
       worker_id: worker_id,
       recurring_task_id: recurring_task_id,
-      finished_at: finished_at
+      finished_at: finished_at,
+      scheduled_at: scheduled_at,
+      enqueued_at: enqueued_at
     }.compact
 
     clone_with(**arguments)
@@ -272,7 +276,15 @@ class ActiveJob::JobsRelation
     end
 
     def satisfy_filter?(job)
-      filters.all? { |property| public_send(property) == job.public_send(property) }
+      filters.all? { |property| satisfies_filter?(public_send(property), job.public_send(property)) }
+    end
+
+    def satisfies_filter?(filter_value, job_value)
+      if filter_value.is_a?(Range)
+        filter_value.cover?(job_value)
+      else
+        filter_value == job_value
+      end
     end
 
     def filters

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -42,7 +42,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
   end
 
   def supported_job_filters(*)
-    [ :queue_name, :job_class_name, :finished_at ]
+    [ :queue_name, :job_class_name, :finished_at, :scheduled_at, :enqueued_at ]
   end
 
   def jobs_count(jobs_relation)
@@ -187,7 +187,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
         attr_reader :jobs_relation
 
         delegate :queue_name, :limit_value, :limit_value_provided?, :offset_value, :job_class_name,
-          :default_page_size, :worker_id, :recurring_task_id, :finished_at, to: :jobs_relation
+          :default_page_size, :worker_id, :recurring_task_id, :finished_at, :scheduled_at, :enqueued_at, to: :jobs_relation
 
         def executions
           execution_class_by_status
@@ -196,6 +196,8 @@ module ActiveJob::QueueAdapters::SolidQueueExt
             .then { |executions| filter_executions_by_class(executions) }
             .then { |executions| filter_executions_by_process_id(executions) }
             .then { |executions| filter_executions_by_task_key(executions) }
+            .then { |executions| filter_executions_by_scheduled_at(executions) }
+            .then { |executions| filter_executions_by_enqueued_at(executions) }
             .then { |executions| limit(executions) }
             .then { |executions| offset(executions) }
         end
@@ -205,6 +207,8 @@ module ActiveJob::QueueAdapters::SolidQueueExt
             .then { |jobs| filter_jobs_by_queue(jobs) }
             .then { |jobs| filter_jobs_by_class(jobs) }
             .then { |jobs| filter_jobs_by_finished_at(jobs) }
+            .then { |jobs| filter_jobs_by_scheduled_at(jobs) }
+            .then { |jobs| filter_jobs_by_enqueued_at(jobs) }
             .then { |jobs| limit(jobs) }
             .then { |jobs| offset(jobs) }
         end
@@ -289,6 +293,29 @@ module ActiveJob::QueueAdapters::SolidQueueExt
 
         def filter_jobs_by_finished_at(jobs)
           finished_at.present? ? jobs.where(finished_at: finished_at) : jobs
+        end
+
+        def filter_executions_by_scheduled_at(executions)
+          return executions unless scheduled_at.present?
+
+          if solid_queue_status.scheduled?
+            executions.where(scheduled_at: scheduled_at)
+          else
+            executions.where(job: { scheduled_at: scheduled_at })
+          end
+        end
+
+        def filter_jobs_by_scheduled_at(jobs)
+          scheduled_at.present? ? jobs.where(scheduled_at: scheduled_at) : jobs
+        end
+
+        # Jobs are created when enqueued
+        def filter_executions_by_enqueued_at(executions)
+          enqueued_at.present? ? executions.where(job: { created_at: enqueued_at }) : executions
+        end
+
+        def filter_jobs_by_enqueued_at(jobs)
+          enqueued_at.present? ? jobs.where(created_at: enqueued_at) : jobs
         end
 
         def limit(executions_or_jobs)

--- a/test/active_job/queue_adapters/adapter_testing/query_jobs.rb
+++ b/test/active_job/queue_adapters/adapter_testing/query_jobs.rb
@@ -116,6 +116,17 @@ module ActiveJob::QueueAdapters::AdapterTesting::QueryJobs
     assert_equal 10, jobs.size
   end
 
+  test "filter jobs by enqueued_at" do
+    3.times { DummyJob.perform_later }
+
+    pending_jobs = ActiveJob.jobs.pending.where(queue_name: :default)
+
+    assert_equal 3, pending_jobs.where(enqueued_at: 1.minute.ago..1.minute.from_now).count
+    assert_equal 3, pending_jobs.where(enqueued_at: 1.minute.ago..).count
+    assert_empty pending_jobs.where(enqueued_at: 1.hour.from_now..)
+    assert_empty pending_jobs.where(enqueued_at: ..1.hour.ago)
+  end
+
   test "fetch jobs in a given queue" do
     DummyJob.queue_as :queue_1
     3.times { DummyJob.perform_later }

--- a/test/active_job/queue_adapters/solid_queue_test.rb
+++ b/test/active_job/queue_adapters/solid_queue_test.rb
@@ -30,6 +30,26 @@ class ActiveJob::QueueAdapters::SolidQueueTest < ActiveSupport::TestCase
     assert_equal 1, ready_execution_counts
   end
 
+  test "filter jobs by scheduled_at and enqueued_at natively" do
+    DummyJob.set(wait: 30.minutes).perform_later(1)
+    DummyJob.set(wait: 3.hours).perform_later(2)
+    DummyJob.perform_later(3)
+    FailingJob.perform_later(4)
+    perform_enqueued_jobs
+
+    scheduled_soon = ActiveJob.jobs.scheduled.where(scheduled_at: Time.now..1.hour.from_now)
+    assert_not scheduled_soon.filtering_needed?
+    assert_equal [ [ 1 ] ], scheduled_soon.map(&:serialized_arguments)
+
+    enqueued_now = ActiveJob.jobs.failed.where(enqueued_at: 1.minute.ago..)
+    assert_not enqueued_now.filtering_needed?
+    assert_equal [ [ 4 ] ], enqueued_now.map(&:serialized_arguments)
+    assert_empty ActiveJob.jobs.failed.where(enqueued_at: ..1.minute.ago)
+
+    assert_equal 1, ActiveJob.jobs.finished.where(enqueued_at: 1.minute.ago..).count
+    assert_empty ActiveJob.jobs.finished.where(scheduled_at: 1.hour.from_now..)
+  end
+
   private
     def queue_adapter
       :solid_queue

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -91,6 +91,52 @@ class MissionControl::Jobs::JobsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "get failed jobs filtered by enqueued_at date" do
+    FailingJob.perform_later(42)
+    perform_enqueued_jobs_async
+
+    get mission_control_jobs.application_jobs_url(@application, :failed)
+    assert_response :ok
+    assert_select "tr.job", 1
+    assert_select "input[name='filter[enqueued_at_start]']"
+    assert_select "input[name='filter[scheduled_at_start]']", 0
+
+    get mission_control_jobs.application_jobs_url(@application, :failed, filter: { enqueued_at_start: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
+    assert_response :ok
+    assert_select "tr.job", 0
+
+    get mission_control_jobs.application_jobs_url(@application, :failed, filter: { enqueued_at_start: 1.hour.ago.strftime("%Y-%m-%dT%H:%M"), enqueued_at_end: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
+    assert_response :ok
+    assert_select "tr.job", 1
+
+    get mission_control_jobs.application_jobs_url(@application, :failed, filter: { enqueued_at_end: 1.hour.ago.strftime("%Y-%m-%dT%H:%M") })
+    assert_response :ok
+    assert_select "tr.job", 0
+  end
+
+  test "get scheduled jobs filtered by scheduled_at date" do
+    DummyJob.set(wait: 30.minutes).perform_later(42)
+    DummyJob.set(wait: 3.hours).perform_later(43)
+
+    get mission_control_jobs.application_jobs_url(@application, :scheduled)
+    assert_response :ok
+    assert_select "tr.job", 2
+    assert_select "input[name='filter[scheduled_at_start]']"
+    assert_select "input[name='filter[finished_at_start]']", 0
+
+    get mission_control_jobs.application_jobs_url(@application, :scheduled, filter: { scheduled_at_start: 1.hour.from_now.strftime("%Y-%m-%dT%H:%M") })
+    assert_response :ok
+    assert_select "tr.job", 1
+
+    get mission_control_jobs.application_jobs_url(@application, :scheduled, filter: { scheduled_at_start: 15.minutes.from_now.strftime("%Y-%m-%dT%H:%M"), scheduled_at_end: 45.minutes.from_now.strftime("%Y-%m-%dT%H:%M") })
+    assert_response :ok
+    assert_select "tr.job", 1
+
+    get mission_control_jobs.application_jobs_url(@application, :scheduled, filter: { scheduled_at_end: 15.minutes.from_now.strftime("%Y-%m-%dT%H:%M") })
+    assert_response :ok
+    assert_select "tr.job", 0
+  end
+
   test "redirect to queue when job doesn't exist" do
     job = DummyJob.perform_later(42)
 


### PR DESCRIPTION
Continues #269 by @jhash (itself a continuation of #209 by @MacLove13): filtering jobs by when they were enqueued, on every status but finished, and by when they're scheduled to run, on the scheduled ones — with the ranges open on either end, like `finished_at`. Recreated as its own PR because #269 is a draft, which maintainers can't push to; the first commit here keeps its authorship.

On top of the original:

- Solid Queue filters natively instead of in memory: scheduled executions on their own indexed `scheduled_at`, other executions and finished jobs through the job's `scheduled_at`, and `enqueued_at` on the job's `created_at`. Other adapters filter in memory, as before (`Range#cover?`).
- The date fields render per status — `finished_at` on Finished, `enqueued_at` elsewhere, `scheduled_at` only on Scheduled — through a shared partial. `enqueued_at` isn't offered on the Finished tab on purpose: that would scan the unindexed `created_at` on the largest table; the console API still allows it.
- The datetime inputs lose the `select` wrapper that drew a spurious dropdown chevron on them. Fixes #232.

Part of #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01451tkCm8XN85boSpVpgSjV
