### PR TITLE
Load the engine's stylesheets under Propshaft too

### DIFF
--- a/app/assets/stylesheets/mission_control/jobs/application.css
+++ b/app/assets/stylesheets/mission_control/jobs/application.css
@@ -1,16 +1,5 @@
 /*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
+ * Application-wide styles. The engine's stylesheets are linked individually from the layout,
+ * so that they load regardless of the host app's asset pipeline: Propshaft serves files as
+ * they are, without processing Sprockets directives.
  */
-

--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -10,7 +10,7 @@
   <meta name="turbo-prefetch" content="false">
 
   <%= stylesheet_link_tag "mission_control/jobs/bulma.min" %>
-  <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
+  <%= stylesheet_link_tag "mission_control/jobs/application", "mission_control/jobs/forms", "mission_control/jobs/jobs", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags "application", importmap: MissionControl::Jobs.importmap  %>
 </head>
 <body>


### PR DESCRIPTION
`application.css` is a Sprockets manifest (`require_tree .`), but Propshaft serves files as they are, without processing directives — so hosts on Propshaft (Rails 8's default, and the dummy app itself) never load `forms.css` or `jobs.css`. Concretely missing today, v1.2.0 included: `word-break` in the job tables, the filter input sizing, the hidden native datalist arrow, and `pointer-events: none` on disabled pagination links.

Fix: link each stylesheet from the layout, which works with both pipelines (the engine's Sprockets manifest already `link_directory`s them for precompilation), and turn `application.css` into a plain stylesheet.

Found while testing #336, whose layout fix had no effect because `jobs.css` never loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
